### PR TITLE
pbrew init: Prefix konfigurieren und Verzeichnisse anlegen

### DIFF
--- a/pbrew/cli/__init__.py
+++ b/pbrew/cli/__init__.py
@@ -7,6 +7,7 @@ from pbrew.cli.clean import clean_cmd
 from pbrew.cli.log_ import log_cmd
 from pbrew.cli.shell_init import shell_init_cmd
 from pbrew.cli.doctor import doctor_cmd
+from pbrew.cli.init_ import init_cmd
 
 
 @click.group()
@@ -29,3 +30,4 @@ main.add_command(clean_cmd, name="clean")
 main.add_command(log_cmd, name="log")
 main.add_command(shell_init_cmd, name="shell-init")
 main.add_command(doctor_cmd, name="doctor")
+main.add_command(init_cmd, name="init")

--- a/pbrew/cli/init_.py
+++ b/pbrew/cli/init_.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import click
+
+from pbrew.core.global_config import global_config_file, write_prefix
+from pbrew.core.paths import (
+    bin_dir,
+    distfiles_dir,
+    etc_dir,
+    get_prefix,
+    state_dir,
+    versions_dir,
+)
+
+
+@click.command("init")
+def init_cmd():
+    """Richtet pbrew ein: Prefix wählen und Verzeichnisse anlegen."""
+    current_default = get_prefix()
+
+    chosen = click.prompt("Installationspräfix", default=str(current_default))
+    prefix = Path(chosen).expanduser().resolve()
+
+    click.echo(f"\nRichte pbrew unter {prefix} ein...\n")
+
+    dirs = [
+        versions_dir(prefix),
+        bin_dir(prefix),
+        etc_dir(prefix),
+        distfiles_dir(prefix),
+        state_dir(prefix),
+    ]
+    for d in dirs:
+        d.mkdir(parents=True, exist_ok=True)
+        click.echo(f"  ✓ {d.relative_to(prefix)}/")
+
+    write_prefix(prefix)
+    click.echo(f"\nKonfiguration gespeichert: {global_config_file()}")
+    click.echo("\npbrew ist eingerichtet. Weiter mit:")
+    click.echo("  pbrew doctor        — Build-Voraussetzungen prüfen")
+    click.echo("  pbrew known         — Verfügbare PHP-Versionen anzeigen")
+    click.echo("  pbrew install 8.4   — PHP 8.4 installieren")

--- a/pbrew/core/global_config.py
+++ b/pbrew/core/global_config.py
@@ -1,0 +1,32 @@
+import os
+from pathlib import Path
+
+import tomlkit
+
+
+def _config_home() -> Path:
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    return Path(xdg) if xdg else Path.home() / ".config"
+
+
+def global_config_file() -> Path:
+    return _config_home() / "pbrew" / "config.toml"
+
+
+def read_configured_prefix() -> "Path | None":
+    f = global_config_file()
+    if not f.exists():
+        return None
+    data = tomlkit.parse(f.read_text())
+    val = data.get("core", {}).get("prefix")
+    return Path(val) if val else None
+
+
+def write_prefix(prefix: Path) -> None:
+    f = global_config_file()
+    f.parent.mkdir(parents=True, exist_ok=True)
+    doc = tomlkit.document()
+    core = tomlkit.table()
+    core.add("prefix", str(prefix))
+    doc.add("core", core)
+    f.write_text(tomlkit.dumps(doc))

--- a/pbrew/core/paths.py
+++ b/pbrew/core/paths.py
@@ -3,10 +3,17 @@ from pathlib import Path
 
 
 def get_prefix() -> Path:
-    """Gibt das pbrew-Prefix zurück (PBREW_ROOT env oder ~/.pbrew)."""
+    """Gibt das pbrew-Prefix zurück.
+
+    Priorität: PBREW_ROOT-Env > ~/.config/pbrew/config.toml > ~/.pbrew
+    """
     env = os.environ.get("PBREW_ROOT")
     if env:
         return Path(env)
+    from pbrew.core.global_config import read_configured_prefix
+    configured = read_configured_prefix()
+    if configured:
+        return configured
     return Path.home() / ".pbrew"
 
 
@@ -53,6 +60,10 @@ def fpm_ini_dir(prefix: Path, family: str) -> Path:
 
 def confd_dir(prefix: Path, family: str) -> Path:
     return etc_dir(prefix) / "conf.d" / family
+
+
+def distfiles_dir(prefix: Path) -> Path:
+    return prefix / "distfiles"
 
 
 def configs_dir(prefix: Path) -> Path:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,80 @@
+import os
+import tomlkit
+from pathlib import Path
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+
+
+def _invoke(tmp_path, user_input):
+    """Ruft `pbrew init` auf mit XDG_CONFIG_HOME in tmp_path."""
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+        return runner.invoke(main, ["init"], input=user_input)
+
+
+def test_init_creates_prefix_directories(tmp_path):
+    prefix = tmp_path / "mypbrew"
+    result = _invoke(tmp_path, str(prefix) + "\n")
+    assert result.exit_code == 0, result.output
+    for subdir in ("versions", "bin", "etc", "distfiles", "state"):
+        assert (prefix / subdir).is_dir(), f"Fehlendes Verzeichnis: {subdir}"
+
+
+def test_init_writes_global_config(tmp_path):
+    prefix = tmp_path / "mypbrew"
+    result = _invoke(tmp_path, str(prefix) + "\n")
+    assert result.exit_code == 0, result.output
+    config_file = tmp_path / "config" / "pbrew" / "config.toml"
+    assert config_file.exists(), "config.toml wurde nicht angelegt"
+    data = tomlkit.parse(config_file.read_text())
+    assert data["core"]["prefix"] == str(prefix)
+
+
+def test_init_default_prefix_is_dot_pbrew(tmp_path):
+    """Enter ohne Eingabe → ~/.pbrew als Standardpräfix."""
+    result = _invoke(tmp_path, "\n")
+    assert result.exit_code == 0, result.output
+    config_file = tmp_path / "config" / "pbrew" / "config.toml"
+    data = tomlkit.parse(config_file.read_text())
+    assert data["core"]["prefix"].endswith(".pbrew")
+
+
+def test_init_expands_tilde(tmp_path):
+    """Tilde-Notation wird zu absolutem Pfad aufgelöst."""
+    result = _invoke(tmp_path, "~/.mypbrew\n")
+    assert result.exit_code == 0, result.output
+    config_file = tmp_path / "config" / "pbrew" / "config.toml"
+    data = tomlkit.parse(config_file.read_text())
+    assert not data["core"]["prefix"].startswith("~")
+
+
+def test_get_prefix_reads_global_config(tmp_path):
+    config_home = tmp_path / "config"
+    (config_home / "pbrew").mkdir(parents=True)
+    doc = tomlkit.document()
+    core = tomlkit.table()
+    core.add("prefix", str(tmp_path / "custom"))
+    doc.add("core", core)
+    (config_home / "pbrew" / "config.toml").write_text(tomlkit.dumps(doc))
+
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(config_home)}):
+        from pbrew.core.paths import get_prefix
+        assert get_prefix() == tmp_path / "custom"
+
+
+def test_get_prefix_env_overrides_config(tmp_path):
+    config_home = tmp_path / "config"
+    (config_home / "pbrew").mkdir(parents=True)
+    doc = tomlkit.document()
+    core = tomlkit.table()
+    core.add("prefix", str(tmp_path / "config-prefix"))
+    doc.add("core", core)
+    (config_home / "pbrew" / "config.toml").write_text(tomlkit.dumps(doc))
+
+    with patch.dict(os.environ, {
+        "XDG_CONFIG_HOME": str(config_home),
+        "PBREW_ROOT": str(tmp_path / "env-prefix"),
+    }):
+        from pbrew.core.paths import get_prefix
+        assert get_prefix() == tmp_path / "env-prefix"


### PR DESCRIPTION
## Summary

- Neuer `pbrew init`-Wizard: fragt nach Installationspräfix (Default `~/.pbrew`) und legt Verzeichnisstruktur an
- Neues Modul `pbrew/core/global_config.py`: persistiert Prefix in `~/.config/pbrew/config.toml` (XDG-konform)
- `get_prefix()` priorisiert jetzt: `PBREW_ROOT`-Env > `config.toml` > `~/.pbrew`
- Neue Pfad-Hilfsfunktion `distfiles_dir()` in `paths.py`
- 6 neue Tests

Closes #1

## Test plan

- [ ] `pbrew init` prompts für Prefix, legt `versions/`, `bin/`, `etc/`, `distfiles/`, `state/` an
- [ ] Konfiguration landet in `~/.config/pbrew/config.toml`
- [ ] Nach `pbrew init` verwendet `pbrew --help` den konfigurierten Prefix
- [ ] `pbrew init` mit Tilde-Eingabe (`~/.mypbrew`) funktioniert
- [ ] `PBREW_ROOT`-Env überschreibt config.toml