### PR TITLE
pbrew init: Shell-Integration (bash/zsh/fish)

### DIFF
--- a/pbrew/cli/init_.py
+++ b/pbrew/cli/init_.py
@@ -11,11 +11,18 @@ from pbrew.core.paths import (
     state_dir,
     versions_dir,
 )
+from pbrew.core.shell import (
+    SHELL_MAP,
+    _rc_file_for,
+    already_integrated,
+    append_shell_integration,
+    detect_shell,
+)
 
 
 @click.command("init")
 def init_cmd():
-    """Richtet pbrew ein: Prefix wählen und Verzeichnisse anlegen."""
+    """Richtet pbrew ein: Prefix wählen, Verzeichnisse anlegen, Shell integrieren."""
     current_default = get_prefix()
 
     chosen = click.prompt("Installationspräfix", default=str(current_default))
@@ -36,7 +43,40 @@ def init_cmd():
 
     write_prefix(prefix)
     click.echo(f"\nKonfiguration gespeichert: {global_config_file()}")
+
+    _setup_shell_integration()
+
     click.echo("\npbrew ist eingerichtet. Weiter mit:")
     click.echo("  pbrew doctor        — Build-Voraussetzungen prüfen")
     click.echo("  pbrew known         — Verfügbare PHP-Versionen anzeigen")
     click.echo("  pbrew install 8.4   — PHP 8.4 installieren")
+
+
+def _setup_shell_integration() -> None:
+    click.echo("\nShell-Integration:")
+    shell = detect_shell()
+    if shell is None:
+        click.echo("  Shell nicht erkannt – bitte manuell einrichten.")
+        _print_manual_hint(None)
+        return
+
+    rc_file = _rc_file_for(shell)
+    snippet = SHELL_MAP[shell]["snippet"]
+
+    if already_integrated(rc_file):
+        click.echo(f"  ✓ Bereits in {rc_file} eingetragen.")
+        return
+
+    if click.confirm(f"  Integration in {rc_file} eintragen?", default=True):
+        append_shell_integration(rc_file, snippet)
+        click.echo(f"  ✓ Eingetragen. Shell neu starten oder: source {rc_file}")
+    else:
+        _print_manual_hint(shell)
+
+
+def _print_manual_hint(shell: "str | None") -> None:
+    if shell and shell in SHELL_MAP:
+        snippet = SHELL_MAP[shell]["snippet"]
+        click.echo(f"  Manuell in die RC-Datei eintragen:\n    {snippet}")
+    else:
+        click.echo("  Manuell in die RC-Datei eintragen: eval \"$(pbrew shell-init bash|zsh)\"")

--- a/pbrew/cli/shell_init.py
+++ b/pbrew/cli/shell_init.py
@@ -34,13 +34,29 @@ pbrew() {{
 '''
 
 
+_FISH_INIT = '''\
+# pbrew shell integration — automatisch generiert von "pbrew shell-init fish"
+set -x PBREW_ROOT "{prefix}"
+fish_add_path "{bin_dir}"
+
+function pbrew
+    if test "$argv[1]" = "use" -o "$argv[1]" = "switch"
+        eval (command pbrew $argv)
+    else
+        command pbrew $argv
+    end
+end
+'''
+
+
 @click.command("shell-init")
-@click.argument("shell", type=click.Choice(["bash", "zsh"]))
+@click.argument("shell", type=click.Choice(["bash", "zsh", "fish"]))
 @click.pass_context
 def shell_init_cmd(ctx, shell):
     """Gibt Shell-Integration aus (in ~/.bashrc oder ~/.zshrc einbinden)."""
     prefix = ctx.obj["prefix"]
-    template = _BASH_INIT if shell == "bash" else _ZSH_INIT
+    templates = {"bash": _BASH_INIT, "zsh": _ZSH_INIT, "fish": _FISH_INIT}
+    template = templates[shell]
     click.echo(template.format(
         prefix=prefix,
         bin_dir=bin_dir(prefix),

--- a/pbrew/core/shell.py
+++ b/pbrew/core/shell.py
@@ -1,0 +1,45 @@
+import os
+from pathlib import Path
+
+_MARKER = "pbrew shell-init"
+
+SHELL_MAP: dict[str, dict] = {
+    "bash": {
+        "snippet": 'eval "$(pbrew shell-init bash)"',
+        "rc": "~/.bashrc",
+    },
+    "zsh": {
+        "snippet": 'eval "$(pbrew shell-init zsh)"',
+        "rc": "~/.zshrc",
+    },
+    "fish": {
+        "snippet": "pbrew shell-init fish | source",
+        "rc": "~/.config/fish/config.fish",
+    },
+}
+
+
+def detect_shell() -> "str | None":
+    """Erkennt die aktive Shell anhand von $SHELL. Gibt None zurück wenn unbekannt."""
+    shell_path = os.environ.get("SHELL", "")
+    name = Path(shell_path).name.lower()
+    return name if name in SHELL_MAP else None
+
+
+def _rc_file_for(shell: str) -> Path:
+    """Gibt den Standardpfad zur RC-Datei für die angegebene Shell zurück."""
+    return Path(SHELL_MAP[shell]["rc"]).expanduser()
+
+
+def already_integrated(rc_file: Path) -> bool:
+    """Prüft, ob pbrew bereits in der RC-Datei eingetragen ist."""
+    if not rc_file.exists():
+        return False
+    return _MARKER in rc_file.read_text()
+
+
+def append_shell_integration(rc_file: Path, snippet: str) -> None:
+    """Hängt den Shell-Integration-Snippet an die RC-Datei an."""
+    rc_file.parent.mkdir(parents=True, exist_ok=True)
+    with rc_file.open("a") as f:
+        f.write(f"\n# pbrew — hinzugefügt von 'pbrew init'\n{snippet}\n")

--- a/tests/test_shell_integration.py
+++ b/tests/test_shell_integration.py
@@ -1,0 +1,143 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+from pbrew.core.shell import detect_shell, already_integrated, append_shell_integration, SHELL_MAP
+
+
+# ---------------------------------------------------------------------------
+# detect_shell
+# ---------------------------------------------------------------------------
+
+def test_detect_shell_bash():
+    with patch.dict(os.environ, {"SHELL": "/bin/bash"}):
+        assert detect_shell() == "bash"
+
+
+def test_detect_shell_zsh():
+    with patch.dict(os.environ, {"SHELL": "/usr/bin/zsh"}):
+        assert detect_shell() == "zsh"
+
+
+def test_detect_shell_fish():
+    with patch.dict(os.environ, {"SHELL": "/usr/bin/fish"}):
+        assert detect_shell() == "fish"
+
+
+def test_detect_shell_unknown_returns_none():
+    with patch.dict(os.environ, {"SHELL": "/bin/tcsh"}):
+        assert detect_shell() is None
+
+
+def test_detect_shell_missing_env_returns_none():
+    env = {k: v for k, v in os.environ.items() if k != "SHELL"}
+    with patch.dict(os.environ, env, clear=True):
+        assert detect_shell() is None
+
+
+# ---------------------------------------------------------------------------
+# already_integrated
+# ---------------------------------------------------------------------------
+
+def test_already_integrated_false_for_missing_file(tmp_path):
+    assert not already_integrated(tmp_path / ".bashrc")
+
+
+def test_already_integrated_false_for_empty_file(tmp_path):
+    rc = tmp_path / ".bashrc"
+    rc.write_text("")
+    assert not already_integrated(rc)
+
+
+def test_already_integrated_true_if_marker_present(tmp_path):
+    rc = tmp_path / ".bashrc"
+    rc.write_text('eval "$(pbrew shell-init bash)"\n')
+    assert already_integrated(rc)
+
+
+# ---------------------------------------------------------------------------
+# append_shell_integration
+# ---------------------------------------------------------------------------
+
+def test_append_creates_file_if_missing(tmp_path):
+    rc = tmp_path / ".bashrc"
+    append_shell_integration(rc, 'eval "$(pbrew shell-init bash)"')
+    assert rc.exists()
+    assert "pbrew shell-init bash" in rc.read_text()
+
+
+def test_append_preserves_existing_content(tmp_path):
+    rc = tmp_path / ".bashrc"
+    rc.write_text("# existing content\n")
+    append_shell_integration(rc, 'eval "$(pbrew shell-init bash)"')
+    text = rc.read_text()
+    assert "# existing content" in text
+    assert "pbrew shell-init bash" in text
+
+
+def test_append_creates_parent_dirs(tmp_path):
+    rc = tmp_path / ".config" / "fish" / "config.fish"
+    append_shell_integration(rc, "pbrew shell-init fish | source")
+    assert rc.exists()
+
+
+# ---------------------------------------------------------------------------
+# pbrew shell-init fish (neues Template)
+# ---------------------------------------------------------------------------
+
+def test_shell_init_fish_outputs_fish_syntax(tmp_path):
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+        result = runner.invoke(main, ["--prefix", str(tmp_path / "pbrew"), "shell-init", "fish"])
+    assert result.exit_code == 0, result.output
+    assert "fish_add_path" in result.output
+    assert "function pbrew" in result.output
+
+
+# ---------------------------------------------------------------------------
+# pbrew init — Shell-Setup-Schritt
+# ---------------------------------------------------------------------------
+
+def test_init_integrates_shell_when_confirmed(tmp_path):
+    runner = CliRunner()
+    prefix = tmp_path / "pbrew"
+    rc_file = tmp_path / ".bashrc"
+    with patch.dict(os.environ, {
+        "SHELL": "/bin/bash",
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+    }), patch("pbrew.cli.init_._rc_file_for", return_value=rc_file):
+        # Eingaben: Präfix-Prompt + Shell-Confirm (y)
+        result = runner.invoke(main, ["init"], input=f"{prefix}\ny\n")
+    assert result.exit_code == 0, result.output
+    assert rc_file.exists()
+    assert "pbrew shell-init bash" in rc_file.read_text()
+
+
+def test_init_skips_shell_when_declined(tmp_path):
+    runner = CliRunner()
+    prefix = tmp_path / "pbrew"
+    rc_file = tmp_path / ".bashrc"
+    with patch.dict(os.environ, {
+        "SHELL": "/bin/bash",
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+    }), patch("pbrew.cli.init_._rc_file_for", return_value=rc_file):
+        result = runner.invoke(main, ["init"], input=f"{prefix}\nn\n")
+    assert result.exit_code == 0, result.output
+    assert not rc_file.exists()
+
+
+def test_init_shell_idempotent(tmp_path):
+    """Zweimaliges init trägt die Integration nicht doppelt ein."""
+    runner = CliRunner()
+    prefix = tmp_path / "pbrew"
+    rc_file = tmp_path / ".bashrc"
+    env = {
+        "SHELL": "/bin/bash",
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+    }
+    with patch.dict(os.environ, env), patch("pbrew.cli.init_._rc_file_for", return_value=rc_file):
+        runner.invoke(main, ["init"], input=f"{prefix}\ny\n")
+        runner.invoke(main, ["init"], input=f"{prefix}\ny\n")
+    count = rc_file.read_text().count("pbrew shell-init bash")
+    assert count == 1, f"Marker {count}× eingetragen statt einmal"


### PR DESCRIPTION
## Summary

- `pbrew init` erkennt aktive Shell via `$SHELL` und bietet RC-Integration an
- Neues Modul `pbrew/core/shell.py`: Shell-Erkennung, Idempotenz-Check, Append
- `pbrew shell-init` unterstützt jetzt auch **fish** (neben bash/zsh)
- Integration wird nur einmal eingetragen (Marker-Check verhindert Duplikate)
- 15 neue Tests

Closes #2

## Test plan

- [ ] `pbrew init` → bash/zsh detected, RC-Datei wird gefragt
- [ ] `pbrew init` zweimal → kein doppelter Eintrag in RC
- [ ] `pbrew shell-init fish` gibt fish-kompatibles Output aus
- [ ] Ablehnen des Prompts → kein RC-Eintrag, manueller Hinweis erscheint