### PR TITLE
pbrew init: Standard-Build-Profile (minimal, standard, dev, prod)

### DIFF
--- a/pbrew/cli/init_.py
+++ b/pbrew/cli/init_.py
@@ -2,9 +2,11 @@ from pathlib import Path
 
 import click
 
+from pbrew.core.config import init_profiles
 from pbrew.core.global_config import global_config_file, write_prefix
 from pbrew.core.paths import (
     bin_dir,
+    configs_dir,
     distfiles_dir,
     etc_dir,
     get_prefix,
@@ -40,6 +42,13 @@ def init_cmd():
     for d in dirs:
         d.mkdir(parents=True, exist_ok=True)
         click.echo(f"  ✓ {d.relative_to(prefix)}/")
+
+    created = init_profiles(configs_dir(prefix))
+    if created:
+        click.echo(f"\nBuild-Profile angelegt: {', '.join(created)}")
+        click.echo("  Verwenden mit: pbrew install 8.4 --config=dev")
+    else:
+        click.echo("\nBuild-Profile: bereits vorhanden.")
 
     write_prefix(prefix)
     click.echo(f"\nKonfiguration gespeichert: {global_config_file()}")

--- a/pbrew/core/config.py
+++ b/pbrew/core/config.py
@@ -64,6 +64,68 @@ def save_config(configs_dir: Path, name: str, data: dict) -> None:
     path.write_text(tomlkit.dumps(data))
 
 
+PRESETS: dict[str, dict] = {
+    "minimal": {
+        "build": {
+            "variants": ["default", "openssl"],
+        },
+        "xdebug": {"enabled": False},
+        "fpm": {"enabled": False},
+    },
+    "standard": {
+        "build": {
+            "variants": [
+                "default", "exif", "fpm", "intl", "mysql", "sqlite",
+                "ftp", "iconv", "gettext", "openssl", "opcache",
+            ],
+        },
+        "xdebug": {"enabled": False},
+    },
+    "dev": {
+        "build": {
+            "variants": [
+                "default", "exif", "fpm", "intl", "mysql", "sqlite",
+                "ftp", "iconv", "gettext", "openssl", "opcache",
+            ],
+        },
+        "xdebug": {"enabled": True},
+    },
+    "prod": {
+        "build": {
+            "variants": [
+                "default", "exif", "fpm", "intl", "mysql", "sqlite",
+                "ftp", "iconv", "gettext", "openssl", "opcache",
+            ],
+        },
+        "xdebug": {"enabled": False},
+        "fpm": {
+            "pool_defaults": {
+                "pm": "dynamic",
+                "pm_max_children": 20,
+                "pm_start_servers": 4,
+                "pm_min_spare_servers": 2,
+                "pm_max_spare_servers": 8,
+            },
+        },
+    },
+}
+
+
+def init_profiles(configs_dir: Path) -> list[str]:
+    """Schreibt Preset-Profile wenn sie noch nicht existieren.
+
+    Gibt die Liste der neu erzeugten Profilnamen zurück.
+    """
+    configs_dir.mkdir(parents=True, exist_ok=True)
+    created = []
+    for name, preset in PRESETS.items():
+        path = configs_dir / f"{name}.toml"
+        if not path.exists():
+            save_config(configs_dir, name, preset)
+            created.append(name)
+    return created
+
+
 def init_default_config(configs_dir: Path) -> None:
     """Schreibt default.toml wenn sie noch nicht existiert."""
     path = configs_dir / "default.toml"

--- a/tests/test_configs_init.py
+++ b/tests/test_configs_init.py
@@ -1,0 +1,76 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+from pbrew.core.config import init_profiles, PRESETS
+
+
+# ---------------------------------------------------------------------------
+# init_profiles
+# ---------------------------------------------------------------------------
+
+def test_init_profiles_creates_all_four(tmp_path):
+    created = init_profiles(tmp_path)
+    assert set(created) == {"minimal", "standard", "dev", "prod"}
+    for name in ("minimal", "standard", "dev", "prod"):
+        assert (tmp_path / f"{name}.toml").exists()
+
+
+def test_init_profiles_does_not_overwrite_existing(tmp_path):
+    import tomlkit
+    (tmp_path / "dev.toml").write_text(tomlkit.dumps({"custom": True}))
+    created = init_profiles(tmp_path)
+    assert "dev" not in created
+    data = tomlkit.loads((tmp_path / "dev.toml").read_text())
+    assert data.get("custom") is True
+
+
+def test_minimal_has_fewer_variants_than_standard(tmp_path):
+    import tomlkit
+    init_profiles(tmp_path)
+    minimal = tomlkit.loads((tmp_path / "minimal.toml").read_text())
+    standard = tomlkit.loads((tmp_path / "standard.toml").read_text())
+    assert len(minimal["build"]["variants"]) < len(standard["build"]["variants"])
+
+
+def test_dev_has_xdebug_enabled(tmp_path):
+    import tomlkit
+    init_profiles(tmp_path)
+    dev = tomlkit.loads((tmp_path / "dev.toml").read_text())
+    assert dev["xdebug"]["enabled"] is True
+
+
+def test_prod_has_xdebug_disabled(tmp_path):
+    import tomlkit
+    init_profiles(tmp_path)
+    prod = tomlkit.loads((tmp_path / "prod.toml").read_text())
+    assert prod["xdebug"]["enabled"] is False
+
+
+def test_all_presets_are_valid_config(tmp_path):
+    """Jedes Preset lässt sich über load_config laden ohne Fehler."""
+    from pbrew.core.config import load_config, init_profiles
+    init_profiles(tmp_path)
+    for name in PRESETS:
+        cfg = load_config(tmp_path, "8.4", named=name)
+        assert "build" in cfg
+        assert "variants" in cfg["build"]
+
+
+# ---------------------------------------------------------------------------
+# pbrew init — Profiles-Schritt
+# ---------------------------------------------------------------------------
+
+def test_init_creates_config_profiles(tmp_path):
+    runner = CliRunner()
+    prefix = tmp_path / "pbrew"
+    with patch.dict(os.environ, {
+        "SHELL": "",
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+    }):
+        result = runner.invoke(main, ["init"], input=f"{prefix}\n")
+    assert result.exit_code == 0, result.output
+    configs = prefix / "configs"
+    for name in ("minimal", "standard", "dev", "prod"):
+        assert (configs / f"{name}.toml").exists(), f"Fehlendes Profil: {name}.toml"


### PR DESCRIPTION
## Summary

- Neues `PRESETS`-Dict in `config.py` mit vier vordefinierten Build-Profilen
- Neue Funktion `init_profiles()`: legt Profile idempotent an
- `pbrew init` ruft `init_profiles()` auf und zeigt erzeugte Profile an
- `pbrew install 8.4 --config=dev` nutzt nun das dev-Profil direkt
- 7 neue Tests

Closes #3

## Profile

| Profil | Xdebug | FPM | Extensions |
|--------|--------|-----|------------|
| minimal | nein | nein | default, openssl |
| standard | nein | ja | + intl, mysql, opcache, … |
| dev | **ja** | ja | wie standard |
| prod | nein | ja | wie standard + erhöhte Pool-Werte |