### PR TITLE
pbrew init: Build-Voraussetzungen prüfen (doctor-Integration)

### DIFF
--- a/pbrew/cli/doctor.py
+++ b/pbrew/cli/doctor.py
@@ -1,14 +1,11 @@
-import shutil
 import sys
 from pathlib import Path
 
 import click
 
 from pbrew.core.paths import bin_dir, family_from_version, versions_dir, state_file
+from pbrew.core.prerequisites import check_prerequisites, install_hint
 from pbrew.core.state import get_family_state
-
-
-_REQUIRED_BINS = ["gcc", "make", "autoconf", "bison", "re2c", "pkg-config"]
 
 
 @click.command("doctor")
@@ -25,10 +22,18 @@ def doctor_cmd(ctx):
     ok_all = ok_all and py_ok
 
     click.echo("\nBinaries:")
-    for binary in _REQUIRED_BINS:
-        found = shutil.which(binary) is not None
-        _show(binary, found)
-        ok_all = ok_all and found
+    results = check_prerequisites()
+    missing = []
+    for r in results:
+        _show(r.name, r.found)
+        ok_all = ok_all and r.found
+        if not r.found:
+            missing.append(r.name)
+
+    if missing:
+        hint = install_hint()
+        if hint:
+            click.echo(f"\n  Fehlende Tools installieren:\n    {hint}")
 
     # Installierte Versionen vs. State-Konsistenz
     vdir = versions_dir(prefix)

--- a/pbrew/cli/init_.py
+++ b/pbrew/cli/init_.py
@@ -13,6 +13,7 @@ from pbrew.core.paths import (
     state_dir,
     versions_dir,
 )
+from pbrew.core.prerequisites import check_prerequisites, install_hint
 from pbrew.core.shell import (
     SHELL_MAP,
     _rc_file_for,
@@ -54,11 +55,28 @@ def init_cmd():
     click.echo(f"\nKonfiguration gespeichert: {global_config_file()}")
 
     _setup_shell_integration()
+    _check_build_prerequisites()
 
     click.echo("\npbrew ist eingerichtet. Weiter mit:")
-    click.echo("  pbrew doctor        — Build-Voraussetzungen prüfen")
     click.echo("  pbrew known         — Verfügbare PHP-Versionen anzeigen")
     click.echo("  pbrew install 8.4   — PHP 8.4 installieren")
+
+
+def _check_build_prerequisites() -> None:
+    click.echo("\nBuild-Voraussetzungen:")
+    results = check_prerequisites()
+    missing = [r.name for r in results if not r.found]
+    for r in results:
+        icon = "✓" if r.found else "✗"
+        click.echo(f"  {icon} {r.name}")
+    if missing:
+        hint = install_hint()
+        if hint:
+            click.echo(f"\n  Fehlende Tools installieren:\n    {hint}")
+        else:
+            click.echo(f"\n  Fehlend: {', '.join(missing)}")
+    else:
+        click.echo("  Alle Build-Tools vorhanden.")
 
 
 def _setup_shell_integration() -> None:

--- a/pbrew/core/prerequisites.py
+++ b/pbrew/core/prerequisites.py
@@ -1,0 +1,35 @@
+import shutil
+from dataclasses import dataclass
+
+REQUIRED_BINS = ["gcc", "make", "autoconf", "bison", "re2c", "pkg-config"]
+
+_INSTALL_HINTS: dict[str, str] = {
+    "apt-get": "sudo apt-get install -y build-essential autoconf bison re2c pkg-config",
+    "dnf": "sudo dnf install -y gcc make autoconf bison re2c pkgconf-pkg-config",
+    "brew": "brew install autoconf bison re2c pkg-config",
+}
+
+
+@dataclass
+class PrerequisiteResult:
+    name: str
+    found: bool
+
+
+def check_prerequisites() -> list[PrerequisiteResult]:
+    """Prüft, ob alle Build-Voraussetzungen installiert sind."""
+    return [PrerequisiteResult(name=b, found=shutil.which(b) is not None) for b in REQUIRED_BINS]
+
+
+def detect_package_manager() -> "str | None":
+    """Erkennt den verfügbaren Paketmanager (apt-get, dnf oder brew)."""
+    for pm in ("apt-get", "dnf", "brew"):
+        if shutil.which(pm):
+            return pm
+    return None
+
+
+def install_hint() -> "str | None":
+    """Gibt den passenden Installationsbefehl für fehlende Build-Tools zurück."""
+    pm = detect_package_manager()
+    return _INSTALL_HINTS.get(pm) if pm else None

--- a/tests/test_prerequisites.py
+++ b/tests/test_prerequisites.py
@@ -1,0 +1,71 @@
+import shutil
+from unittest.mock import patch
+from pbrew.core.prerequisites import (
+    check_prerequisites,
+    detect_package_manager,
+    install_hint,
+    REQUIRED_BINS,
+    PrerequisiteResult,
+)
+
+
+def test_check_prerequisites_returns_one_result_per_bin():
+    results = check_prerequisites()
+    assert len(results) == len(REQUIRED_BINS)
+    assert all(isinstance(r, PrerequisiteResult) for r in results)
+
+
+def test_check_prerequisites_found_for_existing_binary():
+    # gcc ist auf dem Build-System vorhanden
+    results = check_prerequisites()
+    gcc = next(r for r in results if r.name == "gcc")
+    assert gcc.found is (shutil.which("gcc") is not None)
+
+
+def test_check_prerequisites_not_found_for_missing():
+    with patch("pbrew.core.prerequisites.shutil.which", return_value=None):
+        results = check_prerequisites()
+    assert all(not r.found for r in results)
+
+
+def test_detect_package_manager_apt(tmp_path):
+    def fake_which(name):
+        return "/usr/bin/apt-get" if name == "apt-get" else None
+    with patch("pbrew.core.prerequisites.shutil.which", side_effect=fake_which):
+        assert detect_package_manager() == "apt-get"
+
+
+def test_detect_package_manager_none_when_unknown():
+    with patch("pbrew.core.prerequisites.shutil.which", return_value=None):
+        assert detect_package_manager() is None
+
+
+def test_install_hint_returns_string_for_known_pm():
+    with patch("pbrew.core.prerequisites.detect_package_manager", return_value="apt-get"):
+        hint = install_hint()
+    assert hint is not None
+    assert "apt-get" in hint
+
+
+def test_install_hint_returns_none_when_no_pm():
+    with patch("pbrew.core.prerequisites.detect_package_manager", return_value=None):
+        assert install_hint() is None
+
+
+# ---------------------------------------------------------------------------
+# doctor_cmd nutzt check_prerequisites (Refactoring-Test)
+# ---------------------------------------------------------------------------
+
+def test_doctor_uses_prerequisites_module():
+    """doctor_cmd importiert aus prerequisites – kein doppelter shutil.which-Code."""
+    import ast, inspect
+    from pbrew.cli import doctor
+    src = inspect.getsource(doctor)
+    tree = ast.parse(src)
+    # Kein direkter Import von shutil in doctor.py
+    imports = [
+        node.names[0].name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+    ]
+    assert "shutil" not in imports, "doctor.py importiert shutil direkt – bitte prerequisites nutzen"


### PR DESCRIPTION
## Summary

- Neues Modul `pbrew/core/prerequisites.py`: prüft Build-Tools, erkennt Paketmanager, gibt Installationsbefehl zurück
- `pbrew doctor` nutzt jetzt `prerequisites.py` statt eigenem `shutil.which`
- `pbrew init` zeigt am Ende kompakte Prerequisite-Übersicht mit Installationshinweis
- 8 neue Tests, kein Bruch bestehender Tests

Closes #4

## Test plan

- [ ] `pbrew init` zeigt "Alle Build-Tools vorhanden" wenn gcc/make/etc. installiert
- [ ] `pbrew init` zeigt Installationsbefehl wenn Tools fehlen
- [ ] `pbrew doctor` zeigt weiterhin korrekte Binary-Checks (Refactoring)