### PR TITLE
php/phpd-Wrapper: pbrew switch aktualisiert nackte Binaries

### DIFF
--- a/pbrew/cli/install.py
+++ b/pbrew/cli/install.py
@@ -8,10 +8,11 @@ import click
 
 from pbrew.core import builder, config as cfg_mod, resolver, state as state_mod
 from pbrew.core.paths import (
-    bin_dir, build_log, cli_ini_dir, configs_dir,
-    confd_dir, family_from_version, family_suffix, fpm_ini_dir, logs_dir,
+    build_log, cli_ini_dir, configs_dir,
+    confd_dir, family_from_version, fpm_ini_dir, logs_dir,
     state_file, version_dir,
 )
+from pbrew.core.wrappers import write_naked_wrappers, write_versioned_wrappers
 from pbrew.utils import download as dl_mod
 from pbrew.utils.health import run_basic_checks
 
@@ -93,7 +94,9 @@ def install_cmd(ctx, version_spec, config_name, save, jobs):
     sf = state_file(prefix, family)
     state_mod.record_install(sf, version, config=config_name or "default", duration=duration)
 
-    _update_wrappers(prefix, version, family)
+    write_versioned_wrappers(prefix, version, family)
+    if not (prefix / "bin" / "php").exists():
+        write_naked_wrappers(prefix, version, family)
 
     click.echo("  Health-Check...")
     results = run_basic_checks(prefix, version, family, config)
@@ -126,21 +129,3 @@ def _init_php_ini(prefix: Path, version: str, family: str) -> None:
         )
 
 
-def _update_wrappers(prefix: Path, version: str, family: str) -> None:
-    """Erstellt php84, phpize84, php-config84 Wrapper in PREFIX/bin/."""
-    bdir = bin_dir(prefix)
-    bdir.mkdir(parents=True, exist_ok=True)
-
-    suffix = family_suffix(family)
-    php_bin = version_dir(prefix, version) / "bin" / "php"
-    phpize_bin = version_dir(prefix, version) / "bin" / "phpize"
-    php_config_bin = version_dir(prefix, version) / "bin" / "php-config"
-
-    for name, target in [
-        (f"php{suffix}", php_bin),
-        (f"phpize{suffix}", phpize_bin),
-        (f"php-config{suffix}", php_config_bin),
-    ]:
-        wrapper = bdir / name
-        wrapper.write_text(f"#!/bin/bash\nexec {target} \"$@\"\n")
-        wrapper.chmod(0o755)

--- a/pbrew/cli/use.py
+++ b/pbrew/cli/use.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import click
 from pbrew.core.paths import family_from_version, family_suffix, state_file, global_state_file
 from pbrew.core.state import get_family_state, set_global_default
+from pbrew.core.wrappers import write_naked_wrappers
 
 
 @click.command("use")
@@ -27,7 +28,7 @@ def use_cmd(ctx, version_spec):
 @click.argument("version_spec")
 @click.pass_context
 def switch_cmd(ctx, version_spec):
-    """Setzt PHP-Version permanent als Default."""
+    """Setzt PHP-Version permanent als Default und aktualisiert php/phpd-Wrapper."""
     prefix: Path = ctx.obj["prefix"]
     family = family_from_version(version_spec)
     sf = state_file(prefix, family)
@@ -37,5 +38,9 @@ def switch_cmd(ctx, version_spec):
         click.echo(f"PHP {family} ist nicht installiert. Zuerst: pbrew install {family}", err=True)
         raise SystemExit(1)
 
+    version = state["active"]
     set_global_default(global_state_file(prefix), family)
-    click.echo(f"✓ php{family_suffix(family)} ist jetzt der permanente Default (pbrew switch)")
+    write_naked_wrappers(prefix, version, family)
+    click.echo(f"✓ php{family_suffix(family)} ist jetzt der permanente Default")
+    click.echo(f"  php  → {prefix}/bin/php{family_suffix(family)}")
+    click.echo(f"  phpd → {prefix}/bin/php-fpm{family_suffix(family)}")

--- a/pbrew/core/wrappers.py
+++ b/pbrew/core/wrappers.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from pbrew.core.paths import bin_dir, family_suffix, version_dir
+
+
+def write_versioned_wrappers(prefix: Path, version: str, family: str) -> None:
+    """Erstellt php84, phpize84, php-config84 und php-fpm84 in PREFIX/bin/."""
+    bdir = bin_dir(prefix)
+    bdir.mkdir(parents=True, exist_ok=True)
+    suffix = family_suffix(family)
+    vdir = version_dir(prefix, version)
+
+    for name, target in [
+        (f"php{suffix}", vdir / "bin" / "php"),
+        (f"phpize{suffix}", vdir / "bin" / "phpize"),
+        (f"php-config{suffix}", vdir / "bin" / "php-config"),
+        (f"php-fpm{suffix}", vdir / "sbin" / "php-fpm"),
+    ]:
+        wrapper = bdir / name
+        wrapper.write_text(f"#!/bin/bash\nexec {target} \"$@\"\n")
+        wrapper.chmod(0o755)
+
+
+def write_naked_wrappers(prefix: Path, version: str, family: str) -> None:
+    """Aktualisiert die nackten php/phpd-Wrapper auf die angegebene Version.
+
+    php  → delegiert an php{suffix}      (z.B. php84)
+    phpd → delegiert an php-fpm{suffix}  (z.B. php-fpm84)
+    """
+    bdir = bin_dir(prefix)
+    bdir.mkdir(parents=True, exist_ok=True)
+    suffix = family_suffix(family)
+
+    php_wrapper = bdir / "php"
+    php_wrapper.write_text(f"#!/bin/bash\nexec {bdir / f'php{suffix}'} \"$@\"\n")
+    php_wrapper.chmod(0o755)
+
+    phpd_wrapper = bdir / "phpd"
+    phpd_wrapper.write_text(f"#!/bin/bash\nexec {bdir / f'php-fpm{suffix}'} \"$@\"\n")
+    phpd_wrapper.chmod(0o755)

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -1,0 +1,108 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+from pbrew.core.wrappers import write_naked_wrappers, write_versioned_wrappers
+
+
+def _make_version_bins(prefix: Path, version: str) -> None:
+    """Legt Dummy-Binaries für eine PHP-Version an."""
+    vdir = prefix / "versions" / version
+    (vdir / "bin").mkdir(parents=True)
+    (vdir / "sbin").mkdir(parents=True)
+    for name in ("php", "phpize", "php-config"):
+        (vdir / "bin" / name).write_text("#!/bin/bash\n")
+        (vdir / "bin" / name).chmod(0o755)
+    (vdir / "sbin" / "php-fpm").write_text("#!/bin/bash\n")
+    (vdir / "sbin" / "php-fpm").chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# write_versioned_wrappers
+# ---------------------------------------------------------------------------
+
+def test_versioned_wrappers_created(tmp_path):
+    _make_version_bins(tmp_path, "8.4.22")
+    write_versioned_wrappers(tmp_path, "8.4.22", "8.4")
+    bdir = tmp_path / "bin"
+    for name in ("php84", "phpize84", "php-config84", "php-fpm84"):
+        wrapper = bdir / name
+        assert wrapper.exists(), f"Fehlt: {name}"
+        assert wrapper.stat().st_mode & 0o111, f"Nicht ausführbar: {name}"
+
+
+def test_versioned_wrapper_executes_correct_binary(tmp_path):
+    _make_version_bins(tmp_path, "8.3.10")
+    write_versioned_wrappers(tmp_path, "8.3.10", "8.3")
+    content = (tmp_path / "bin" / "php83").read_text()
+    assert "versions/8.3.10/bin/php" in content
+
+
+# ---------------------------------------------------------------------------
+# write_naked_wrappers
+# ---------------------------------------------------------------------------
+
+def test_naked_php_wrapper_created(tmp_path):
+    (tmp_path / "bin").mkdir()
+    write_naked_wrappers(tmp_path, "8.4.22", "8.4")
+    php = tmp_path / "bin" / "php"
+    assert php.exists()
+    assert php.stat().st_mode & 0o111
+
+
+def test_naked_phpd_wrapper_created(tmp_path):
+    (tmp_path / "bin").mkdir()
+    write_naked_wrappers(tmp_path, "8.4.22", "8.4")
+    phpd = tmp_path / "bin" / "phpd"
+    assert phpd.exists()
+    assert phpd.stat().st_mode & 0o111
+
+
+def test_naked_php_delegates_to_versioned_wrapper(tmp_path):
+    (tmp_path / "bin").mkdir()
+    write_naked_wrappers(tmp_path, "8.4.22", "8.4")
+    content = (tmp_path / "bin" / "php").read_text()
+    assert "php84" in content
+
+
+def test_naked_phpd_delegates_to_fpm_wrapper(tmp_path):
+    (tmp_path / "bin").mkdir()
+    write_naked_wrappers(tmp_path, "8.4.22", "8.4")
+    content = (tmp_path / "bin" / "phpd").read_text()
+    assert "php-fpm84" in content
+
+
+def test_naked_wrappers_overwritten_on_switch(tmp_path):
+    """Nach switch auf 8.3 verweisen php/phpd auf php83/php-fpm83."""
+    (tmp_path / "bin").mkdir()
+    write_naked_wrappers(tmp_path, "8.4.22", "8.4")
+    write_naked_wrappers(tmp_path, "8.3.10", "8.3")  # switch
+    content = (tmp_path / "bin" / "php").read_text()
+    assert "php83" in content
+    assert "php84" not in content
+
+
+# ---------------------------------------------------------------------------
+# pbrew switch aktualisiert naked wrappers
+# ---------------------------------------------------------------------------
+
+def test_switch_updates_naked_wrappers(tmp_path):
+    import json
+    # State vorbereiten: 8.4.22 installiert und aktiv
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "8.4.json").write_text(json.dumps({"active": "8.4.22"}))
+    (tmp_path / "bin").mkdir()
+    # Versioned wrapper muss existieren damit naked wrapper drauf zeigen kann
+    (tmp_path / "bin" / "php84").write_text("#!/bin/bash\n")
+    (tmp_path / "bin" / "php-fpm84").write_text("#!/bin/bash\n")
+
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+        result = runner.invoke(main, ["--prefix", str(tmp_path), "switch", "8.4"])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "bin" / "php").exists()
+    assert (tmp_path / "bin" / "phpd").exists()
+    content = (tmp_path / "bin" / "php").read_text()
+    assert "php84" in content


### PR DESCRIPTION
## Summary

- Neues Modul `pbrew/core/wrappers.py`: `write_versioned_wrappers()` und `write_naked_wrappers()`
- `install.py` nutzt `write_versioned_wrappers()` (kein duplizierer Code mehr), legt `php`/`phpd` bei Erstinstallation an
- `pbrew switch <version>` schreibt `php` und `phpd` neu – zeigt Ziel-Wrapper im Output
- `php-fpm84` wird als versionierter Wrapper neu angelegt

Closes #5

## Test plan

- [ ] `pbrew install 8.4` legt `bin/php84`, `bin/php-fpm84`, `bin/php`, `bin/phpd` an
- [ ] `pbrew switch 8.3` (nach Install 8.3) überschreibt `bin/php` → zeigt `php83`
- [ ] `cat ~/.pbrew/bin/phpd` zeigt `exec … php-fpm84`