### PR TITLE
Distfiles-Cache: distfiles_dir() + pbrew cleanup

### DIFF
--- a/pbrew/cli/__init__.py
+++ b/pbrew/cli/__init__.py
@@ -8,6 +8,7 @@ from pbrew.cli.log_ import log_cmd
 from pbrew.cli.shell_init import shell_init_cmd
 from pbrew.cli.doctor import doctor_cmd
 from pbrew.cli.init_ import init_cmd
+from pbrew.cli.cleanup import cleanup_cmd
 
 
 @click.group()
@@ -31,3 +32,4 @@ main.add_command(log_cmd, name="log")
 main.add_command(shell_init_cmd, name="shell-init")
 main.add_command(doctor_cmd, name="doctor")
 main.add_command(init_cmd, name="init")
+main.add_command(cleanup_cmd, name="cleanup")

--- a/pbrew/cli/cleanup.py
+++ b/pbrew/cli/cleanup.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import click
+
+from pbrew.core.paths import distfiles_dir, state_dir, versions_dir, state_file, family_from_version
+from pbrew.core.state import get_family_state
+
+
+@click.command("cleanup")
+@click.option("--dry-run", is_flag=True, help="Zeigt was gelöscht würde, ohne zu löschen")
+@click.pass_context
+def cleanup_cmd(ctx, dry_run):
+    """Entfernt Tarballs von nicht installierten PHP-Versionen aus dem Distfiles-Cache."""
+    prefix: Path = ctx.obj["prefix"]
+
+    installed = _collect_installed_versions(prefix)
+    ddir = distfiles_dir(prefix)
+
+    if not ddir.exists():
+        click.echo("Distfiles-Verzeichnis nicht gefunden.")
+        return
+
+    removed = 0
+    for tarball in sorted(ddir.glob("php-*.tar.bz2")):
+        version = tarball.name.removeprefix("php-").removesuffix(".tar.bz2")
+        if version not in installed:
+            size_mb = tarball.stat().st_size / 1_048_576
+            click.echo(f"  {'[dry-run] ' if dry_run else ''}Entferne {tarball.name} ({size_mb:.1f} MB)")
+            if not dry_run:
+                tarball.unlink()
+            removed += 1
+
+    if removed == 0:
+        click.echo("Keine veralteten Tarballs gefunden.")
+    elif not dry_run:
+        click.echo(f"\n✓ {removed} Tarball(s) gelöscht.")
+    else:
+        click.echo(f"\n{removed} Tarball(s) würden gelöscht (--dry-run).")
+
+
+def _collect_installed_versions(prefix: Path) -> set[str]:
+    """Gibt alle bekannten installierten Versionen aus dem State zurück."""
+    installed: set[str] = set()
+    sdir = state_dir(prefix)
+    if not sdir.exists():
+        return installed
+    for state_path in sdir.glob("*.json"):
+        if state_path.stem == "global":
+            continue
+        state = get_family_state(state_path)
+        installed.update(state.get("installed", {}).keys())
+        if state.get("active"):
+            installed.add(state["active"])
+    return installed

--- a/pbrew/cli/install.py
+++ b/pbrew/cli/install.py
@@ -8,7 +8,7 @@ import click
 
 from pbrew.core import builder, config as cfg_mod, resolver, state as state_mod
 from pbrew.core.paths import (
-    build_log, cli_ini_dir, configs_dir,
+    build_log, cli_ini_dir, configs_dir, distfiles_dir,
     confd_dir, family_from_version, fpm_ini_dir, logs_dir,
     state_file, version_dir,
 )
@@ -47,7 +47,7 @@ def install_cmd(ctx, version_spec, config_name, save, jobs):
         cfg_mod.save_config(cfgs_dir, config_name, config)
         click.echo(f"  Config als '{config_name}' gespeichert.")
 
-    dist_dir = prefix / "distfiles"
+    dist_dir = distfiles_dir(prefix)
     tarball = dist_dir / f"php-{version}.tar.bz2"
     if not tarball.exists():
         click.echo(f"  Lade php-{version}.tar.bz2 herunter...")

--- a/tests/test_distfiles.py
+++ b/tests/test_distfiles.py
@@ -1,0 +1,76 @@
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from click.testing import CliRunner
+from pbrew.cli import main
+
+
+def _setup_prefix(prefix: Path, version: str = "8.4.22", family: str = "8.4") -> None:
+    """Legt ein minimales Prefix für Tests an."""
+    (prefix / "distfiles").mkdir(parents=True)
+    (prefix / "state").mkdir(parents=True)
+    (prefix / "bin").mkdir(parents=True)
+
+
+# ---------------------------------------------------------------------------
+# distfiles_dir aus paths.py
+# ---------------------------------------------------------------------------
+
+def test_distfiles_dir_returns_correct_path(tmp_path):
+    from pbrew.core.paths import distfiles_dir
+    assert distfiles_dir(tmp_path) == tmp_path / "distfiles"
+
+
+# ---------------------------------------------------------------------------
+# install nutzt distfiles_dir aus paths
+# ---------------------------------------------------------------------------
+
+def test_install_uses_distfiles_dir(tmp_path):
+    """install.py darf prefix / 'distfiles' nicht hardcoden."""
+    import ast, inspect
+    from pbrew.cli import install
+    src = inspect.getsource(install)
+    tree = ast.parse(src)
+    # Suche nach direkten String-Konstruktionen wie prefix / "distfiles"
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and node.value == "distfiles":
+            raise AssertionError(
+                "install.py enthält hardcodierten 'distfiles'-String — bitte distfiles_dir() verwenden"
+            )
+
+
+# ---------------------------------------------------------------------------
+# pbrew cleanup
+# ---------------------------------------------------------------------------
+
+def test_cleanup_removes_old_tarballs(tmp_path):
+    _setup_prefix(tmp_path)
+    # Zwei Tarballs anlegen, 8.4.20 ist nicht mehr installiert
+    (tmp_path / "distfiles" / "php-8.4.20.tar.bz2").write_bytes(b"old")
+    (tmp_path / "distfiles" / "php-8.4.22.tar.bz2").write_bytes(b"current")
+    # State: 8.4.22 aktiv installiert
+    (tmp_path / "state" / "8.4.json").write_text(json.dumps({
+        "active": "8.4.22",
+        "installed": {"8.4.22": {}},
+    }))
+
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+        result = runner.invoke(main, ["--prefix", str(tmp_path), "cleanup"])
+    assert result.exit_code == 0, result.output
+    assert not (tmp_path / "distfiles" / "php-8.4.20.tar.bz2").exists()
+    assert (tmp_path / "distfiles" / "php-8.4.22.tar.bz2").exists()
+
+
+def test_cleanup_dry_run_does_not_delete(tmp_path):
+    _setup_prefix(tmp_path)
+    (tmp_path / "distfiles" / "php-8.4.20.tar.bz2").write_bytes(b"old")
+    (tmp_path / "state" / "8.4.json").write_text(json.dumps({"installed": {}}))
+
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+        result = runner.invoke(main, ["--prefix", str(tmp_path), "cleanup", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "distfiles" / "php-8.4.20.tar.bz2").exists()
+    assert "php-8.4.20.tar.bz2" in result.output


### PR DESCRIPTION
## Summary

- `install.py` nutzt `distfiles_dir(prefix)` statt `prefix / "distfiles"` (hardcode entfernt)
- Neuer Command `pbrew cleanup`: entfernt Tarballs nicht installierter Versionen
- `--dry-run`-Flag: zeigt was gelöscht würde, ohne zu löschen
- 4 neue Tests

Closes #6