### PR TITLE
Config-Tracking: Build-Variants und Config-Name im State speichern

### DIFF
--- a/pbrew/cli/install.py
+++ b/pbrew/cli/install.py
@@ -92,7 +92,12 @@ def install_cmd(ctx, version_spec, config_name, save, jobs):
     _init_php_ini(prefix, version, family)
 
     sf = state_file(prefix, family)
-    state_mod.record_install(sf, version, config=config_name or "default", duration=duration)
+    state_mod.record_install(
+        sf, version,
+        config=config_name or "default",
+        duration=duration,
+        variants=config.get("build", {}).get("variants"),
+    )
 
     write_versioned_wrappers(prefix, version, family)
     if not (prefix / "bin" / "php").exists():

--- a/pbrew/core/state.py
+++ b/pbrew/core/state.py
@@ -61,8 +61,9 @@ def record_install(
     version: str,
     config: str = "default",
     duration: float | None = None,
+    variants: "list[str] | None" = None,
 ) -> None:
-    """Setzt active, config, installed_at und optional build_duration in einem Write."""
+    """Setzt active, config, installed_at, variants und optional build_duration in einem Write."""
     state = _load(state_file)
     if "active" in state and state["active"] != version:
         state["previous"] = state["active"]
@@ -70,6 +71,9 @@ def record_install(
     state["config"] = config
     entry = state.setdefault("installed", {}).setdefault(version, {})
     entry["installed_at"] = datetime.now(timezone.utc).isoformat()
+    entry["config_name"] = config
+    if variants is not None:
+        entry["variants"] = variants
     if duration is not None:
         entry["build_duration_seconds"] = round(duration)
     _save(state_file, state)

--- a/tests/test_config_tracking.py
+++ b/tests/test_config_tracking.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+from pbrew.core.state import record_install, get_family_state
+
+
+# ---------------------------------------------------------------------------
+# record_install speichert variants
+# ---------------------------------------------------------------------------
+
+def test_record_install_stores_variants(tmp_path):
+    sf = tmp_path / "8.4.json"
+    variants = ["default", "fpm", "intl", "mysql", "opcache"]
+    record_install(sf, "8.4.22", config="dev", variants=variants)
+    state = get_family_state(sf)
+    assert state["installed"]["8.4.22"]["variants"] == variants
+
+
+def test_record_install_stores_config_name_in_entry(tmp_path):
+    sf = tmp_path / "8.4.json"
+    record_install(sf, "8.4.22", config="prod", variants=["default"])
+    state = get_family_state(sf)
+    assert state["installed"]["8.4.22"]["config_name"] == "prod"
+
+
+def test_record_install_without_variants_still_works(tmp_path):
+    """Variants-Parameter ist optional – bestehende Aufrufe ohne ihn funktionieren weiter."""
+    sf = tmp_path / "8.4.json"
+    record_install(sf, "8.4.22", config="default")
+    state = get_family_state(sf)
+    assert "8.4.22" in state["installed"]
+    # variants ist None oder nicht vorhanden – kein Fehler
+    entry = state["installed"]["8.4.22"]
+    assert "variants" not in entry or entry["variants"] is None
+
+
+def test_record_install_overwrites_previous_variants(tmp_path):
+    """Zweiter Install mit anderen Variants überschreibt den vorherigen Eintrag."""
+    sf = tmp_path / "8.4.json"
+    record_install(sf, "8.4.22", config="standard", variants=["default", "fpm"])
+    record_install(sf, "8.4.22", config="dev", variants=["default", "fpm", "xdebug"])
+    state = get_family_state(sf)
+    assert state["installed"]["8.4.22"]["variants"] == ["default", "fpm", "xdebug"]
+
+
+# ---------------------------------------------------------------------------
+# install_cmd übergibt variants an record_install
+# ---------------------------------------------------------------------------
+
+def test_install_cmd_passes_variants_to_record_install(tmp_path):
+    """Smoke-Test: install.py ruft record_install mit variants auf."""
+    import ast, inspect
+    from pbrew.cli import install
+    src = inspect.getsource(install)
+    tree = ast.parse(src)
+    # Suche nach record_install-Aufruf mit variants-Argument
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            name = getattr(func, "attr", None) or getattr(func, "id", None)
+            if name == "record_install":
+                keywords = [kw.arg for kw in node.keywords]
+                assert "variants" in keywords, \
+                    "record_install wird ohne 'variants'-Argument aufgerufen"
+                return
+    raise AssertionError("record_install nicht in install.py gefunden")


### PR DESCRIPTION
## Summary

- `record_install()` erhält neuen `variants`-Parameter (optional, rückwärtskompatibel)
- Pro Build-Eintrag werden gespeichert: `config_name`, `variants` (Liste der Build-Extensions)
- `install_cmd` übergibt die tatsächlich genutzten Variants aus dem `config`-Dict
- Grundlage für `pbrew upgrade`, das denselben Binary-Fingerabdruck reproduzieren kann
- 5 neue Tests

Closes #8