### PR TITLE
pbrew info: Detail-Ansicht einer installierten PHP-Version

### DIFF
--- a/pbrew/cli/__init__.py
+++ b/pbrew/cli/__init__.py
@@ -10,6 +10,7 @@ from pbrew.cli.doctor import doctor_cmd
 from pbrew.cli.init_ import init_cmd
 from pbrew.cli.cleanup import cleanup_cmd
 from pbrew.cli.update import update_cmd
+from pbrew.cli.info import info_cmd
 
 
 @click.group()
@@ -35,3 +36,4 @@ main.add_command(doctor_cmd, name="doctor")
 main.add_command(init_cmd, name="init")
 main.add_command(cleanup_cmd, name="cleanup")
 main.add_command(update_cmd, name="update")
+main.add_command(info_cmd, name="info")

--- a/pbrew/cli/info.py
+++ b/pbrew/cli/info.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import click
+
+from pbrew.core.paths import (
+    bin_dir,
+    family_from_version,
+    family_suffix,
+    global_state_file,
+    state_file,
+    version_dir,
+)
+from pbrew.core.state import get_family_state, get_global_state
+
+
+@click.command("info")
+@click.argument("version_spec")
+@click.pass_context
+def info_cmd(ctx, version_spec):
+    """Zeigt Detailinformationen zu einer installierten PHP-Version."""
+    prefix: Path = ctx.obj["prefix"]
+    family = family_from_version(version_spec)
+    state = get_family_state(state_file(prefix, family))
+
+    # Version auflösen: '8.4' → aktive Version der Family
+    version = version_spec if version_spec.count(".") == 2 else state.get("active")
+    if not version:
+        click.echo(f"PHP {family} ist nicht installiert.", err=True)
+        raise SystemExit(1)
+
+    vdir = version_dir(prefix, version)
+    if not vdir.exists():
+        click.echo(f"PHP {version} ist nicht installiert (kein Verzeichnis: {vdir}).", err=True)
+        raise SystemExit(1)
+
+    entry = state.get("installed", {}).get(version, {})
+    global_state = get_global_state(global_state_file(prefix))
+    suffix = family_suffix(family)
+
+    is_active = state.get("active") == version
+    is_default_family = global_state.get("default_family") == family
+    status_parts = []
+    if is_active:
+        status_parts.append("aktiv")
+    if is_default_family and is_active:
+        status_parts.append("Family-Default")
+    status = ", ".join(status_parts) if status_parts else "installiert (nicht aktiv)"
+
+    click.echo(f"\nPHP {version} (Family {family})")
+    click.echo(f"  Pfad:         {vdir}")
+    click.echo(f"  Installiert:  {entry.get('installed_at', '—')}")
+    click.echo(f"  Build-Dauer:  {_format_duration(entry.get('build_duration_seconds'))}")
+    click.echo(f"  Config:       {entry.get('config_name', '—')}")
+    click.echo(f"  Variants:     {_format_variants(entry.get('variants'))}")
+    click.echo(f"  Wrapper:      {bin_dir(prefix) / f'php{suffix}'}, {bin_dir(prefix) / f'php-fpm{suffix}'}")
+    click.echo(f"  Status:       {status}")
+    click.echo()
+
+
+def _format_duration(seconds) -> str:
+    if not seconds:
+        return "—"
+    minutes, secs = divmod(int(seconds), 60)
+    return f"{minutes}m {secs}s" if minutes else f"{secs}s"
+
+
+def _format_variants(variants) -> str:
+    if not variants:
+        return "—"
+    return ", ".join(variants)

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,0 +1,107 @@
+import json
+import os
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+
+
+def _write_state(prefix, family, data):
+    state_dir = prefix / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / f"{family}.json").write_text(json.dumps(data))
+
+
+def _make_install(prefix, version):
+    vdir = prefix / "versions" / version
+    (vdir / "bin").mkdir(parents=True)
+    (vdir / "bin" / "php").write_text("#!/bin/bash\n")
+
+
+# ---------------------------------------------------------------------------
+# info — Glücksfall: alles vorhanden
+# ---------------------------------------------------------------------------
+
+def test_info_shows_version_details(tmp_path):
+    _make_install(tmp_path, "8.4.22")
+    _write_state(tmp_path, "8.4", {
+        "active": "8.4.22",
+        "installed": {
+            "8.4.22": {
+                "installed_at": "2026-04-15T14:23:45+00:00",
+                "build_duration_seconds": 133,
+                "config_name": "dev",
+                "variants": ["default", "fpm", "intl", "opcache"],
+            },
+        },
+    })
+    _write_state(tmp_path, "global", {})  # Placeholder, doesn't matter
+
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+        result = runner.invoke(main, ["--prefix", str(tmp_path), "info", "8.4.22"])
+    assert result.exit_code == 0, result.output
+    assert "8.4.22" in result.output
+    assert "dev" in result.output
+    assert "fpm" in result.output
+    assert "opcache" in result.output
+
+
+def test_info_shows_active_marker(tmp_path):
+    _make_install(tmp_path, "8.4.22")
+    _write_state(tmp_path, "8.4", {
+        "active": "8.4.22",
+        "installed": {"8.4.22": {"config_name": "standard"}},
+    })
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+        result = runner.invoke(main, ["--prefix", str(tmp_path), "info", "8.4.22"])
+    assert result.exit_code == 0, result.output
+    assert "aktiv" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# info — nicht installiert
+# ---------------------------------------------------------------------------
+
+def test_info_exits_when_version_not_installed(tmp_path):
+    (tmp_path / "versions").mkdir()  # leer
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+        result = runner.invoke(main, ["--prefix", str(tmp_path), "info", "8.4.22"])
+    assert result.exit_code != 0
+    assert "nicht installiert" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# info — Legacy-Install ohne Metadaten
+# ---------------------------------------------------------------------------
+
+def test_info_handles_legacy_install_without_metadata(tmp_path):
+    """Version existiert auf Disk, aber State ist leer (z.B. manuell installiert)."""
+    _make_install(tmp_path, "8.3.10")
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+        result = runner.invoke(main, ["--prefix", str(tmp_path), "info", "8.3.10"])
+    assert result.exit_code == 0, result.output
+    assert "8.3.10" in result.output
+    # Keine Metadaten – darf aber nicht crashen
+    assert "—" in result.output or "unbekannt" in result.output.lower() or "keine" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# info — Family als Argument (statt expliziter Version)
+# ---------------------------------------------------------------------------
+
+def test_info_accepts_family_and_resolves_to_active(tmp_path):
+    """`pbrew info 8.4` sollte die aktive Version der Family anzeigen."""
+    _make_install(tmp_path, "8.4.22")
+    _write_state(tmp_path, "8.4", {
+        "active": "8.4.22",
+        "installed": {"8.4.22": {"config_name": "prod"}},
+    })
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+        result = runner.invoke(main, ["--prefix", str(tmp_path), "info", "8.4"])
+    assert result.exit_code == 0, result.output
+    assert "8.4.22" in result.output
+    assert "prod" in result.output


### PR DESCRIPTION
## Summary

- Neuer Command `pbrew info <version|family>`
- Zeigt: Pfad, Installationsdatum, Build-Dauer, Config-Name, Variants, Wrapper, Status
- Akzeptiert explizite Version (`8.4.22`) oder Family (`8.4` → aktive Version)
- Robust gegen Legacy-Installs ohne Metadaten (zeigt `—`)
- 5 neue Tests

Closes #18