### PR TITLE
pbrew env: aktuelle Shell-Umgebung anzeigen

### DIFF
--- a/pbrew/cli/__init__.py
+++ b/pbrew/cli/__init__.py
@@ -11,6 +11,7 @@ from pbrew.cli.init_ import init_cmd
 from pbrew.cli.cleanup import cleanup_cmd
 from pbrew.cli.update import update_cmd
 from pbrew.cli.info import info_cmd
+from pbrew.cli.env import env_cmd
 
 
 @click.group()
@@ -37,3 +38,4 @@ main.add_command(init_cmd, name="init")
 main.add_command(cleanup_cmd, name="cleanup")
 main.add_command(update_cmd, name="update")
 main.add_command(info_cmd, name="info")
+main.add_command(env_cmd, name="env")

--- a/pbrew/cli/env.py
+++ b/pbrew/cli/env.py
@@ -1,0 +1,52 @@
+import os
+import re
+from pathlib import Path
+
+import click
+
+from pbrew.core.paths import bin_dir, global_state_file
+from pbrew.core.state import get_global_state
+
+
+@click.command("env")
+@click.pass_context
+def env_cmd(ctx):
+    """Zeigt pbrew-relevante Umgebungsvariablen und die aktive Shell-Konfiguration."""
+    prefix: Path = ctx.obj["prefix"]
+    bdir = bin_dir(prefix)
+
+    click.echo("\nUmgebung:")
+    click.echo(f"  PBREW_ROOT:   {prefix}")
+
+    pbrew_php = os.environ.get("PBREW_PHP")
+    click.echo(f"  PBREW_PHP:    {pbrew_php or '—'}")
+
+    path = os.environ.get("PATH", "")
+    path_contains = str(bdir) in path.split(":")
+    click.echo(f"  PATH:         {bdir} {'(vorhanden)' if path_contains else '(fehlt)'}")
+
+    global_state = get_global_state(global_state_file(prefix))
+    default_family = global_state.get("default_family")
+    click.echo(f"  Default:      {default_family or '—'}")
+
+    click.echo("\nNackte Wrapper:")
+    for name in ("php", "phpd"):
+        target = _resolve_wrapper_target(bdir / name)
+        click.echo(f"  {name:<5} → {target}")
+
+    click.echo()
+
+
+def _resolve_wrapper_target(wrapper: Path) -> str:
+    """Liest das exec-Ziel aus einem Bash-Wrapper-Skript."""
+    if not wrapper.exists():
+        return "(nicht vorhanden)"
+    try:
+        text = wrapper.read_text()
+    except OSError:
+        return "(unlesbar)"
+    match = re.search(r"exec\s+(\S+)", text)
+    if not match:
+        return "(Format unbekannt)"
+    target = Path(match.group(1)).name
+    return target

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,81 @@
+import json
+import os
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+
+
+def _setup_global_state(prefix, default_family=None):
+    state_dir = prefix / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    state = {}
+    if default_family:
+        state["default_family"] = default_family
+    (state_dir / "global.json").write_text(json.dumps(state))
+
+
+def _setup_naked_wrapper(prefix, target_name):
+    bdir = prefix / "bin"
+    bdir.mkdir(parents=True, exist_ok=True)
+    (bdir / "php").write_text(f'#!/bin/bash\nexec {bdir / target_name} "$@"\n')
+
+
+def _invoke(prefix, tmp_path, env=None):
+    base_env = {"XDG_CONFIG_HOME": str(tmp_path / "config")}
+    if env:
+        base_env.update(env)
+    runner = CliRunner()
+    with patch.dict(os.environ, base_env, clear=False):
+        return runner.invoke(main, ["--prefix", str(prefix), "env"])
+
+
+# ---------------------------------------------------------------------------
+# env zeigt Basis-Informationen
+# ---------------------------------------------------------------------------
+
+def test_env_shows_pbrew_root(tmp_path):
+    result = _invoke(tmp_path, tmp_path)
+    assert result.exit_code == 0, result.output
+    assert "PBREW_ROOT" in result.output
+    assert str(tmp_path) in result.output
+
+
+def test_env_shows_default_family(tmp_path):
+    _setup_global_state(tmp_path, default_family="8.4")
+    result = _invoke(tmp_path, tmp_path)
+    assert result.exit_code == 0, result.output
+    assert "8.4" in result.output
+
+
+def test_env_shows_pbrew_php_when_set(tmp_path):
+    _setup_global_state(tmp_path)
+    result = _invoke(tmp_path, tmp_path, env={"PBREW_PHP": "8.3"})
+    assert result.exit_code == 0, result.output
+    assert "8.3" in result.output
+    assert "PBREW_PHP" in result.output
+
+
+def test_env_shows_naked_wrapper_target(tmp_path):
+    """Wenn bin/php existiert, zeigt env das Ziel des Wrappers."""
+    _setup_naked_wrapper(tmp_path, "php84")
+    _setup_global_state(tmp_path)
+    result = _invoke(tmp_path, tmp_path)
+    assert result.exit_code == 0, result.output
+    assert "php84" in result.output
+
+
+def test_env_handles_missing_naked_wrapper(tmp_path):
+    """Kein bin/php vorhanden → kein Crash, Hinweis wird angezeigt."""
+    _setup_global_state(tmp_path)
+    result = _invoke(tmp_path, tmp_path)
+    assert result.exit_code == 0, result.output
+    # Muss laufen, darf keinen KeyError werfen
+
+
+def test_env_shows_path_status(tmp_path):
+    """env zeigt ob ~/.pbrew/bin/ im PATH ist."""
+    _setup_global_state(tmp_path)
+    bdir = str(tmp_path / "bin")
+    result = _invoke(tmp_path, tmp_path, env={"PATH": f"{bdir}:/usr/bin"})
+    assert result.exit_code == 0, result.output
+    assert "PATH" in result.output


### PR DESCRIPTION
## Summary

- Neuer Command `pbrew env` zeigt:
  - `PBREW_ROOT`, `PBREW_PHP` aus `os.environ`
  - PATH-Status (ist `{prefix}/bin/` enthalten?)
  - Default-Family aus global state
  - Ziele der nackten Wrapper `php` und `phpd` (gelesen aus Wrapper-Skripten)
- 6 neue Tests

Closes #24