### PR TITLE
pbrew outdated: zeigt welche installierten Familien Updates haben

### DIFF
--- a/pbrew/cli/__init__.py
+++ b/pbrew/cli/__init__.py
@@ -12,6 +12,7 @@ from pbrew.cli.cleanup import cleanup_cmd
 from pbrew.cli.update import update_cmd
 from pbrew.cli.info import info_cmd
 from pbrew.cli.env import env_cmd
+from pbrew.cli.outdated import outdated_cmd
 
 
 @click.group()
@@ -39,3 +40,4 @@ main.add_command(cleanup_cmd, name="cleanup")
 main.add_command(update_cmd, name="update")
 main.add_command(info_cmd, name="info")
 main.add_command(env_cmd, name="env")
+main.add_command(outdated_cmd, name="outdated")

--- a/pbrew/cli/outdated.py
+++ b/pbrew/cli/outdated.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import click
+
+from pbrew.core.paths import state_dir, state_file
+from pbrew.core.resolver import fetch_latest
+from pbrew.core.state import get_family_state
+
+
+@click.command("outdated")
+@click.pass_context
+def outdated_cmd(ctx):
+    """Zeigt, welche installierten PHP-Familien Updates haben (Exit 1 wenn ja, 0 wenn alle aktuell)."""
+    prefix: Path = ctx.obj["prefix"]
+    families = _installed_families(prefix)
+
+    if not families:
+        click.echo("Keine PHP-Familien installiert.")
+        return
+
+    click.echo(f"\n{'Family':<8} {'Installiert':<14} {'Neueste':<12} Status")
+    click.echo("─" * 55)
+
+    has_updates = False
+    for family in sorted(families):
+        state = get_family_state(state_file(prefix, family))
+        active = state.get("active", "—")
+        try:
+            release = fetch_latest(family)
+            latest = release.version
+            if latest == active:
+                status = "✓ aktuell"
+            else:
+                status = "↑ Update verfügbar"
+                has_updates = True
+        except Exception as exc:
+            latest = "?"
+            status = f"✗ Fehler: {exc}"
+
+        click.echo(f"  {family:<8} {active:<14} {latest:<12} {status}")
+
+    click.echo()
+    if has_updates:
+        raise SystemExit(1)
+
+
+def _installed_families(prefix: Path) -> list[str]:
+    sdir = state_dir(prefix)
+    if not sdir.exists():
+        return []
+    families = []
+    for state_path in sdir.glob("*.json"):
+        if state_path.stem == "global":
+            continue
+        state = get_family_state(state_path)
+        if state.get("active"):
+            families.append(state_path.stem)
+    return families

--- a/tests/test_outdated.py
+++ b/tests/test_outdated.py
@@ -1,0 +1,100 @@
+import json
+import os
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+from pbrew.core.resolver import PhpRelease
+
+
+def _make_release(version: str) -> PhpRelease:
+    family = ".".join(version.split(".")[:2])
+    return PhpRelease(
+        version=version,
+        family=family,
+        tarball_url=f"https://www.php.net/distributions/php-{version}.tar.bz2",
+        sha256="abc",
+    )
+
+
+def _setup(prefix, family, active_version):
+    vdir = prefix / "versions" / active_version
+    (vdir / "bin").mkdir(parents=True)
+    state_dir = prefix / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / f"{family}.json").write_text(json.dumps({"active": active_version}))
+
+
+def _invoke(prefix, tmp_path, fetch_side_effect):
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}), \
+         patch("pbrew.cli.outdated.fetch_latest", side_effect=fetch_side_effect):
+        return runner.invoke(main, ["--prefix", str(prefix), "outdated"])
+
+
+# ---------------------------------------------------------------------------
+# outdated: alles aktuell
+# ---------------------------------------------------------------------------
+
+def test_outdated_all_current(tmp_path):
+    _setup(tmp_path, "8.4", "8.4.22")
+    result = _invoke(tmp_path, tmp_path, lambda family: _make_release("8.4.22"))
+    assert result.exit_code == 0, result.output
+    assert "aktuell" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# outdated: Update verfügbar → Exit 1
+# ---------------------------------------------------------------------------
+
+def test_outdated_shows_available_update(tmp_path):
+    _setup(tmp_path, "8.3", "8.3.10")
+    result = _invoke(tmp_path, tmp_path, lambda family: _make_release("8.3.12"))
+    assert result.exit_code == 1, result.output
+    assert "8.3.10" in result.output
+    assert "8.3.12" in result.output
+    assert "verfügbar" in result.output.lower() or "update" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# outdated: mehrere Familien mit gemischtem Status
+# ---------------------------------------------------------------------------
+
+def test_outdated_mixed_status(tmp_path):
+    _setup(tmp_path, "8.4", "8.4.22")
+    _setup(tmp_path, "8.3", "8.3.10")
+    responses = {"8.4": _make_release("8.4.22"), "8.3": _make_release("8.3.12")}
+    result = _invoke(tmp_path, tmp_path, lambda family: responses[family])
+    assert result.exit_code == 1  # mindestens eine Family hat Update
+    assert "8.4.22" in result.output
+    assert "8.3.12" in result.output
+
+
+# ---------------------------------------------------------------------------
+# outdated: keine Familien installiert
+# ---------------------------------------------------------------------------
+
+def test_outdated_no_families_installed(tmp_path):
+    (tmp_path / "state").mkdir()  # leer
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+        result = runner.invoke(main, ["--prefix", str(tmp_path), "outdated"])
+    assert result.exit_code == 0
+    assert "keine" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# outdated: Netzwerkfehler pro Family soll Gesamtlauf nicht abbrechen
+# ---------------------------------------------------------------------------
+
+def test_outdated_handles_fetch_errors_gracefully(tmp_path):
+    _setup(tmp_path, "8.4", "8.4.22")
+    _setup(tmp_path, "8.3", "8.3.10")
+
+    def fetcher(family):
+        if family == "8.3":
+            raise RuntimeError("Netzwerkfehler")
+        return _make_release("8.4.22")
+
+    result = _invoke(tmp_path, tmp_path, fetcher)
+    assert "8.4.22" in result.output
+    assert "fehler" in result.output.lower() or "netzwerk" in result.output.lower()


### PR DESCRIPTION
## Summary

- Neuer Command `pbrew outdated`
- Pro installierter Family: aktive Version vs. neueste Version von php.net
- Status: `✓ aktuell` oder `↑ Update verfügbar`
- Exit-Code 1 wenn mind. eine Family outdated → CI-tauglich
- Netzwerkfehler pro Family: Status `✗ Fehler: <msg>`, Gesamtlauf läuft weiter
- 5 neue Tests

Closes #25