### PR TITLE
Builder: configure-Flags für PHP 8.x-Variants korrigieren

### DIFF
--- a/pbrew/core/builder.py
+++ b/pbrew/core/builder.py
@@ -5,11 +5,39 @@ from typing import IO
 
 from pbrew.core.paths import version_dir, cli_ini_dir, confd_dir
 
-# Variants die --enable-X statt --with-X verwenden
-_ENABLE_VARIANTS = frozenset({
-    "cli", "fpm", "opcache", "exif", "intl", "gettext",
-    "ftp", "soap", "tidy", "iconv",
-})
+# Variant → Liste von configure-Flags.
+# Explizites Mapping statt Heuristik: einige Variants brauchen mehrere Flags
+# (z.B. mysql → mysqli + pdo-mysql mit mysqlnd-Treiber), manche hängen von
+# externen Libs ab und müssen --with- statt --enable- nutzen.
+_VARIANT_FLAGS: dict[str, list[str]] = {
+    # Built-in / SAPI
+    "cli":          ["--enable-cli"],
+    "fpm":          ["--enable-fpm"],
+    "fpm-systemd":  ["--enable-fpm", "--with-fpm-systemd"],  # braucht libsystemd-dev
+    # Core-Extensions (--enable-, eingebaut)
+    "opcache":      ["--enable-opcache"],
+    "exif":         ["--enable-exif"],
+    "intl":         ["--enable-intl"],          # braucht libicu-dev
+    "ftp":          ["--enable-ftp"],
+    "soap":         ["--enable-soap"],          # braucht libxml2-dev
+    "mbstring":     ["--enable-mbstring"],
+    "bcmath":       ["--enable-bcmath"],
+    "sockets":      ["--enable-sockets"],
+    # Extensions mit externer Lib (--with-)
+    "openssl":      ["--with-openssl"],
+    "iconv":        ["--with-iconv"],
+    "gettext":      ["--with-gettext"],
+    "tidy":         ["--with-tidy"],
+    "curl":         ["--with-curl"],
+    "zip":          ["--with-zip"],
+    "bz2":          ["--with-bz2"],
+    "zlib":         ["--with-zlib"],
+    "readline":     ["--with-readline"],
+    # Spezielle 1:N-Mappings
+    "mysql":        ["--enable-mysqli", "--with-mysqli=mysqlnd", "--with-pdo-mysql=mysqlnd"],
+    "sqlite":       ["--with-sqlite3", "--with-pdo-sqlite"],
+    "pgsql":        ["--with-pgsql", "--with-pdo-pgsql"],
+}
 
 
 def build_configure_args(
@@ -23,7 +51,6 @@ def build_configure_args(
     cli_ini = cli_ini_dir(prefix, family)
     scan_dir = confd_dir(prefix, family)
 
-    # Basis-Argumente (können durch build.extra überschrieben werden)
     base = {
         "prefix": str(vdir),
         "with-config-file-path": str(cli_ini),
@@ -31,29 +58,28 @@ def build_configure_args(
     }
 
     extra = config.get("build", {}).get("extra", {})
-    # Explizite extra-Optionen überschreiben unsere Defaults
     for key in ("with-config-file-path", "with-config-file-scan-dir"):
         if key in extra:
             base[key] = extra[key]
 
     args = [
         f"--prefix={base['prefix']}",
-        "--enable-cli",
-        "--enable-fpm",
-        "--with-fpm-systemd",
+        "--enable-cli",  # Basis: immer CLI bauen
         f"--with-config-file-path={base['with-config-file-path']}",
         f"--with-config-file-scan-dir={base['with-config-file-scan-dir']}",
     ]
 
-    # Variants
+    seen: set[str] = set(args)
     variants = config.get("build", {}).get("variants", [])
     for variant in variants:
-        if variant in ("default", "fpm", "cli"):
+        if variant in ("default", "cli"):
             continue
-        flag = "--enable-" if variant in _ENABLE_VARIANTS else "--with-"
-        args.append(f"{flag}{variant}")
+        flags = _VARIANT_FLAGS.get(variant, [f"--enable-{variant}"])
+        for flag in flags:
+            if flag not in seen:
+                args.append(flag)
+                seen.add(flag)
 
-    # Extra-Optionen (außer bereits verarbeitete)
     skip = {"prefix", "with-config-file-path", "with-config-file-scan-dir"}
     for key, value in extra.items():
         if key in skip:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -11,10 +11,16 @@ def test_configure_args_contains_prefix():
     assert any("versions/8.4.22" in a for a in args)
 
 
-def test_configure_args_contains_cli_and_fpm():
+def test_configure_args_contains_cli():
+    """cli wird immer als Basis hinzugefügt (kein Variant)."""
     args = build_configure_args(PREFIX, "8.4.22", "8.4", {})
     assert "--enable-cli" in args
-    assert "--enable-fpm" in args
+
+
+def test_configure_args_fpm_only_when_in_variants():
+    """fpm darf nur hinzukommen, wenn in variants gelistet."""
+    args = build_configure_args(PREFIX, "8.4.22", "8.4", {"build": {"variants": ["default"]}})
+    assert "--enable-fpm" not in args
 
 
 def test_configure_args_sets_config_file_path():
@@ -59,3 +65,78 @@ def test_get_jobs_fixed():
 
 def test_get_jobs_override():
     assert get_jobs({"build": {"jobs": "auto"}}, override=2) == 2
+
+
+# ---------------------------------------------------------------------------
+# Variant-Mapping (#29)
+# ---------------------------------------------------------------------------
+
+def test_no_fpm_systemd_by_default():
+    """--with-fpm-systemd darf nicht automatisch gesetzt werden (libsystemd-Abhängigkeit)."""
+    config = {"build": {"variants": ["default", "fpm"]}}
+    args = build_configure_args(PREFIX, "8.4.22", "8.4", config)
+    assert "--with-fpm-systemd" not in args
+
+
+def test_fpm_systemd_as_explicit_variant():
+    """fpm-systemd als eigener Variant aktiviert --with-fpm-systemd."""
+    config = {"build": {"variants": ["fpm-systemd"]}}
+    args = build_configure_args(PREFIX, "8.4.22", "8.4", config)
+    assert "--enable-fpm" in args
+    assert "--with-fpm-systemd" in args
+
+
+def test_mysql_variant_maps_to_mysqli_and_pdo():
+    """mysql → mysqli + pdo-mysql mit mysqlnd-Treiber (seit PHP 7.0)."""
+    config = {"build": {"variants": ["mysql"]}}
+    args = build_configure_args(PREFIX, "8.4.22", "8.4", config)
+    assert "--enable-mysqli" in args
+    assert "--with-mysqli=mysqlnd" in args
+    assert "--with-pdo-mysql=mysqlnd" in args
+    assert "--with-mysql" not in args  # vor PHP 7.0 entfernt
+
+
+def test_sqlite_variant_maps_to_sqlite3_and_pdo():
+    config = {"build": {"variants": ["sqlite"]}}
+    args = build_configure_args(PREFIX, "8.4.22", "8.4", config)
+    assert "--with-sqlite3" in args
+    assert "--with-pdo-sqlite" in args
+    assert "--with-sqlite" not in args
+
+
+def test_iconv_uses_with_not_enable():
+    config = {"build": {"variants": ["iconv"]}}
+    args = build_configure_args(PREFIX, "8.4.22", "8.4", config)
+    assert "--with-iconv" in args
+    assert "--enable-iconv" not in args
+
+
+def test_tidy_uses_with_not_enable():
+    config = {"build": {"variants": ["tidy"]}}
+    args = build_configure_args(PREFIX, "8.4.22", "8.4", config)
+    assert "--with-tidy" in args
+    assert "--enable-tidy" not in args
+
+
+def test_gettext_uses_with_not_enable():
+    config = {"build": {"variants": ["gettext"]}}
+    args = build_configure_args(PREFIX, "8.4.22", "8.4", config)
+    assert "--with-gettext" in args
+    assert "--enable-gettext" not in args
+
+
+def test_unknown_variant_falls_back_to_enable():
+    """Variant ohne explizites Mapping bekommt standardmäßig --enable-X."""
+    config = {"build": {"variants": ["customextension"]}}
+    args = build_configure_args(PREFIX, "8.4.22", "8.4", config)
+    assert "--enable-customextension" in args
+
+
+def test_minimal_profile_produces_clean_args():
+    """Minimal-Profil soll nur cli + default erzeugen – kein FPM."""
+    config = {"build": {"variants": ["default", "openssl"]}}
+    args = build_configure_args(PREFIX, "8.4.22", "8.4", config)
+    assert "--enable-cli" in args
+    assert "--with-openssl" in args
+    assert "--enable-fpm" not in args
+    assert "--with-fpm-systemd" not in args


### PR DESCRIPTION
## Summary

Behebt den realen Build-Fehler:
\`\`\`
configure: error: Package requirements (libsystemd >= 209) were not met
\`\`\`

### Änderungen

- **\`--with-fpm-systemd\` nicht mehr automatisch** – als separater Variant \`fpm-systemd\`
- **\`--enable-fpm\` nur noch wenn in variants gelistet** – nicht mehr fix
- **\`_VARIANT_FLAGS\`-Mapping** ersetzt die \`_ENABLE_VARIANTS\`-Heuristik
- 1:N-Mappings:
  - \`mysql\` → \`--enable-mysqli --with-mysqli=mysqlnd --with-pdo-mysql=mysqlnd\` (PHP 7.0+ kompatibel)
  - \`sqlite\` → \`--with-sqlite3 --with-pdo-sqlite\`
  - \`pgsql\` → \`--with-pgsql --with-pdo-pgsql\`
- Korrekte Flags: \`iconv\`, \`tidy\`, \`gettext\` → \`--with-X\` (externe Libs)
- Neue Variants: mbstring, bcmath, sockets, curl, zip, bz2, zlib, readline

### Tests

- 9 neue Builder-Tests, alle grün
- Bestehende 11 weiterhin grün

Closes #29