### PR TITLE
pbrew install: Phasen-Feedback und tail-Hinweis

### DIFF
--- a/pbrew/cli/install.py
+++ b/pbrew/cli/install.py
@@ -71,23 +71,22 @@ def install_cmd(ctx, version_spec, config_name, save, jobs):
     cli_ini_dir(prefix, family).mkdir(parents=True, exist_ok=True)
     confd_dir(prefix, family).mkdir(parents=True, exist_ok=True)
 
-    click.echo(f"  Baue PHP {version} mit {num_jobs} Jobs...")
-    start = time.monotonic()
+    click.echo(f"\n  Baue PHP {version} mit {num_jobs} Jobs")
+    click.echo(f"  Build-Log: {log_path}")
+    click.echo(f"  (Live verfolgen: tail -f {log_path})\n")
 
+    start = time.monotonic()
     with open(log_path, "w") as log:
-        try:
-            args = builder.build_configure_args(prefix, version, family, config)
-            builder.run_configure(build_dir, args, log)
-            builder.run_make(build_dir, num_jobs, log)
-            builder.run_make_install(build_dir, log)
-        except Exception as exc:
-            shutil.rmtree(build_dir, ignore_errors=True)
-            click.echo(f"\n  Fehler beim Build. Log: {log_path}", err=True)
-            click.echo(f"  {exc}", err=True)
-            sys.exit(1)
+        args = builder.build_configure_args(prefix, version, family, config)
+        _run_phase("configure", lambda: builder.run_configure(build_dir, args, log),
+                   build_dir, log_path)
+        _run_phase(f"make -j{num_jobs}", lambda: builder.run_make(build_dir, num_jobs, log),
+                   build_dir, log_path)
+        _run_phase("make install", lambda: builder.run_make_install(build_dir, log),
+                   build_dir, log_path)
 
     duration = time.monotonic() - start
-    click.echo(f"  Build abgeschlossen ({duration:.0f}s)")
+    click.echo(f"\n  Build abgeschlossen ({_fmt_duration(duration)})")
 
     _init_php_ini(prefix, version, family)
 
@@ -114,6 +113,31 @@ def install_cmd(ctx, version_spec, config_name, save, jobs):
         click.echo("  Warnung: Einige Checks fehlgeschlagen. Log: " + str(log_path), err=True)
 
     click.echo(f"✓ PHP {version} installiert.")
+
+
+def _run_phase(name: str, action, build_dir: Path, log_path: Path) -> None:
+    """Führt eine Build-Phase aus, misst die Zeit und berichtet Erfolg/Fehler."""
+    click.echo(f"  → {name}...", nl=False)
+    phase_start = time.monotonic()
+    try:
+        action()
+    except Exception as exc:
+        elapsed = time.monotonic() - phase_start
+        click.echo(f" ✗ ({_fmt_duration(elapsed)})")
+        click.echo(f"\n  Fehler in Phase '{name}' nach {_fmt_duration(elapsed)}", err=True)
+        click.echo(f"  Log: {log_path}", err=True)
+        click.echo(f"  {exc}", err=True)
+        shutil.rmtree(build_dir, ignore_errors=True)
+        sys.exit(1)
+    elapsed = time.monotonic() - phase_start
+    click.echo(f" ✓ ({_fmt_duration(elapsed)})")
+
+
+def _fmt_duration(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.0f}s"
+    minutes, secs = divmod(int(seconds), 60)
+    return f"{minutes}m {secs}s"
 
 
 def _init_php_ini(prefix: Path, version: str, family: str) -> None:

--- a/tests/test_install_ux.py
+++ b/tests/test_install_ux.py
@@ -1,0 +1,106 @@
+"""Tests für den Install-Output (nicht den echten Build – der läuft per Integrationstest)."""
+import json
+import os
+import tarfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from click.testing import CliRunner
+
+from pbrew.cli import main
+from pbrew.core.resolver import PhpRelease
+
+
+def _make_release(version="8.4.22"):
+    family = ".".join(version.split(".")[:2])
+    return PhpRelease(
+        version=version,
+        family=family,
+        tarball_url=f"https://www.php.net/distributions/php-{version}.tar.bz2",
+        sha256="abc",
+    )
+
+
+def _prepare_prefix(prefix: Path, version="8.4.22"):
+    """Legt alles außer versions/<v>/ an – das erzeugt erst der gemockte 'make install'."""
+    for sub in ("distfiles", "state", "bin", "etc", "configs"):
+        (prefix / sub).mkdir(parents=True, exist_ok=True)
+    (prefix / "distfiles" / f"php-{version}.tar.bz2").write_bytes(b"")
+    build_dir = prefix / "build" / version
+    build_dir.mkdir(parents=True)
+    return build_dir
+
+
+def _simulate_make_install(prefix: Path, version: str):
+    """Erzeugt die Binary-Struktur, die make install normalerweise anlegen würde."""
+    vdir = prefix / "versions" / version
+    (vdir / "bin").mkdir(parents=True)
+    (vdir / "bin" / "php").write_text("#!/bin/bash\n")
+    (vdir / "bin" / "php").chmod(0o755)
+    (vdir / "sbin").mkdir()
+    (vdir / "sbin" / "php-fpm").write_text("#!/bin/bash\n")
+
+
+def _invoke_install(prefix, tmp_path, version="8.4.22"):
+    runner = CliRunner()
+    env = {"XDG_CONFIG_HOME": str(tmp_path / "config")}
+    with patch.dict(os.environ, env), \
+         patch("pbrew.cli.install.resolver.fetch_latest", return_value=_make_release(version)), \
+         patch("pbrew.cli.install.builder.run_configure", return_value=None) as mc, \
+         patch("pbrew.cli.install.builder.run_make", return_value=None) as mm, \
+         patch("pbrew.cli.install.builder.run_make_install",
+               side_effect=lambda *a, **kw: _simulate_make_install(prefix, version)) as mi, \
+         patch("pbrew.cli.install.run_basic_checks", return_value=[]):
+        result = runner.invoke(main, ["--prefix", str(prefix), "install", "8.4"])
+        return result, (mc, mm, mi)
+
+
+# ---------------------------------------------------------------------------
+# Log-Pfad und Tail-Hinweis werden VOR dem Build angezeigt
+# ---------------------------------------------------------------------------
+
+def test_output_shows_log_path_and_tail_hint(tmp_path):
+    prefix = tmp_path / "pbrew"
+    _prepare_prefix(prefix)
+    result, _ = _invoke_install(prefix, tmp_path)
+    assert result.exit_code == 0, result.output
+    assert "Build-Log:" in result.output
+    assert "tail -f" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Jede Phase erscheint einzeln im Output
+# ---------------------------------------------------------------------------
+
+def test_output_shows_each_phase(tmp_path):
+    prefix = tmp_path / "pbrew"
+    _prepare_prefix(prefix)
+    result, _ = _invoke_install(prefix, tmp_path)
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "configure" in out.lower()
+    assert "make" in out.lower()
+    assert "install" in out.lower()
+    # Phasen müssen in dieser Reihenfolge erscheinen
+    assert out.lower().index("configure") < out.lower().index("make ")
+    # Erfolgs-Icon nach jeder Phase
+    assert out.count("✓") >= 3  # 3 Phasen
+
+
+# ---------------------------------------------------------------------------
+# Bei Phasen-Fehler wird die betroffene Phase genannt
+# ---------------------------------------------------------------------------
+
+def test_error_in_configure_reports_which_phase(tmp_path):
+    prefix = tmp_path / "pbrew"
+    _prepare_prefix(prefix)
+    runner = CliRunner()
+    env = {"XDG_CONFIG_HOME": str(tmp_path / "config")}
+    with patch.dict(os.environ, env), \
+         patch("pbrew.cli.install.resolver.fetch_latest", return_value=_make_release()), \
+         patch("pbrew.cli.install.builder.run_configure",
+               side_effect=RuntimeError("bison not found")):
+        result = runner.invoke(main, ["--prefix", str(prefix), "install", "8.4"])
+    assert result.exit_code != 0
+    assert "configure" in result.output.lower()
+    assert "bison" in result.output.lower()


### PR DESCRIPTION
## Summary

Statt stummem Warten zeigt \`pbrew install\` jetzt vor dem Build den Log-Pfad mit \`tail -f\`-Hinweis und pro Phase (configure / make / make install) einen Zwischenstand mit Timing.

### Vorher

\`\`\`
  Baue PHP 8.4.20 mit 12 Jobs...
  [... 3 Minuten stille Warten ...]
  Build abgeschlossen (180s)
\`\`\`

### Nachher

\`\`\`
  Baue PHP 8.4.20 mit 12 Jobs
  Build-Log: ~/.pbrew/state/logs/8.4.20-build.log
  (Live verfolgen: tail -f ~/.pbrew/state/logs/8.4.20-build.log)

  → configure... ✓ (32s)
  → make -j12... ✓ (2m 14s)
  → make install... ✓ (8s)

  Build abgeschlossen (2m 54s)
\`\`\`

Bei Fehler wird die betroffene Phase benannt – spart das Suchen im Log.

### Changes

- Helper \`_run_phase(name, action, build_dir, log_path)\`
- Helper \`_fmt_duration(seconds)\` – smart zwischen `30s` und `2m 14s`
- 3 neue Tests (Log-Hinweis, Phasenreihenfolge, Phasen-Fehlermeldung)

Closes #33