### PR TITLE
pbrew install: Fehlerzeilen aus Build-Log bei Phasen-Fehler anzeigen

### DIFF
--- a/pbrew/cli/install.py
+++ b/pbrew/cli/install.py
@@ -126,7 +126,14 @@ def _run_phase(name: str, action, build_dir: Path, log_path: Path) -> None:
         click.echo(f" ✗ ({_fmt_duration(elapsed)})")
         click.echo(f"\n  Fehler in Phase '{name}' nach {_fmt_duration(elapsed)}", err=True)
         click.echo(f"  Log: {log_path}", err=True)
-        click.echo(f"  {exc}", err=True)
+
+        errors = _extract_errors_from_log(log_path)
+        if errors:
+            click.echo("\n  Letzte Fehlerzeilen aus dem Log:", err=True)
+            for line in errors:
+                click.echo(f"    {line}", err=True)
+
+        click.echo(f"\n  {exc}", err=True)
         shutil.rmtree(build_dir, ignore_errors=True)
         sys.exit(1)
     elapsed = time.monotonic() - phase_start
@@ -138,6 +145,45 @@ def _fmt_duration(seconds: float) -> str:
         return f"{seconds:.0f}s"
     minutes, secs = divmod(int(seconds), 60)
     return f"{minutes}m {secs}s"
+
+
+def _extract_errors_from_log(
+    log_path: Path,
+    max_matches: int = 5,
+    context_after: int = 2,
+    fallback_tail: int = 15,
+) -> list[str]:
+    """Extrahiert aussagekräftige Fehlerzeilen aus einem Build-Log.
+
+    Strategie:
+    1. Case-insensitive nach 'error:'-Treffern suchen, die letzten `max_matches`
+       nehmen und je `context_after` Folgezeilen als Kontext anhängen
+    2. Kein Match → die letzten `fallback_tail` Zeilen zurückgeben
+    3. Log fehlt oder leer → leere Liste
+    """
+    if not log_path.exists():
+        return []
+    try:
+        lines = log_path.read_text(errors="replace").splitlines()
+    except OSError:
+        return []
+    if not lines:
+        return []
+
+    error_indices = [i for i, line in enumerate(lines) if "error:" in line.lower()]
+
+    if not error_indices:
+        return lines[-fallback_tail:]
+
+    selected: list[str] = []
+    seen: set[int] = set()
+    for idx in error_indices[-max_matches:]:
+        for offset in range(context_after + 1):
+            i = idx + offset
+            if i < len(lines) and i not in seen:
+                selected.append(lines[i])
+                seen.add(i)
+    return selected
 
 
 def _init_php_ini(prefix: Path, version: str, family: str) -> None:

--- a/tests/test_log_errors.py
+++ b/tests/test_log_errors.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+from pbrew.cli.install import _extract_errors_from_log
+
+
+def test_extracts_configure_error_line(tmp_path):
+    log = tmp_path / "build.log"
+    log.write_text(
+        "checking for icu... no\n"
+        "configure: error: Package requirements (icu-uc >= 50.1) were not met:\n"
+        "No package 'icu-uc' found\n"
+    )
+    lines = _extract_errors_from_log(log)
+    assert any("icu-uc" in l for l in lines)
+    assert any("Package requirements" in l for l in lines)
+
+
+def test_includes_context_after_error(tmp_path):
+    """Folgezeilen direkt nach einer error-Zeile werden als Kontext mitgenommen."""
+    log = tmp_path / "build.log"
+    log.write_text(
+        "configure: error: something went wrong\n"
+        "  additional context line 1\n"
+        "  additional context line 2\n"
+        "unrelated line at end\n"
+    )
+    lines = _extract_errors_from_log(log)
+    text = "\n".join(lines)
+    assert "something went wrong" in text
+    assert "context line 1" in text
+
+
+def test_shows_last_errors_when_many(tmp_path):
+    """Bei vielen error-Zeilen nur die letzten paar zeigen, sonst wird es unlesbar."""
+    log = tmp_path / "build.log"
+    content = "\n".join([f"error: failure {i}" for i in range(50)])
+    log.write_text(content)
+    lines = _extract_errors_from_log(log, max_matches=3)
+    assert len(lines) <= 10  # 3 errors + kleiner Kontext je, nicht alle 50
+    # Die letzten errors müssen drin sein
+    text = "\n".join(lines)
+    assert "failure 49" in text
+    assert "failure 0" not in text
+
+
+def test_fallback_to_tail_when_no_error_keyword(tmp_path):
+    """Wenn keine error-Zeile gefunden, zeige die letzten Zeilen als Fallback."""
+    log = tmp_path / "build.log"
+    content = "\n".join([f"line {i}" for i in range(30)])
+    log.write_text(content)
+    lines = _extract_errors_from_log(log)
+    assert len(lines) > 0
+    text = "\n".join(lines)
+    assert "line 29" in text  # letzte Zeile muss drin sein
+
+
+def test_handles_missing_log(tmp_path):
+    """Existiert das Log nicht (z.B. Exception vor open), kein Crash."""
+    lines = _extract_errors_from_log(tmp_path / "does-not-exist.log")
+    assert lines == []
+
+
+def test_handles_empty_log(tmp_path):
+    log = tmp_path / "build.log"
+    log.write_text("")
+    lines = _extract_errors_from_log(log)
+    assert lines == []


### PR DESCRIPTION
## Summary

Bei einem Phasen-Fehler werden jetzt die echten Fehlermeldungen aus dem Log direkt im Terminal angezeigt – kein \`tail\`/\`grep\` mehr nötig.

### Vorher

\`\`\`
  Fehler in Phase 'configure' nach 48s
  Log: ~/.pbrew/state/logs/8.4.20-build.log
  Command '[...]' returned non-zero exit status 1.
\`\`\`

### Nachher

\`\`\`
  Fehler in Phase 'configure' nach 48s
  Log: ~/.pbrew/state/logs/8.4.20-build.log

  Letzte Fehlerzeilen aus dem Log:
    configure: error: Package requirements (icu-uc >= 50.1) were not met
    No package 'icu-uc' found

  Command '[...]' returned non-zero exit status 1.
\`\`\`

### Implementation

- Neuer Helper \`_extract_errors_from_log(log_path, max_matches, context_after, fallback_tail)\`
- Sucht case-insensitive nach \`error:\`, nimmt die letzten 5 Treffer + 2 Kontextzeilen
- Kein \`error:\`-Match → Fallback auf die letzten 15 Zeilen
- Robust gegen fehlendes/leeres Log
- 6 neue Tests

Closes #35