### PR TITLE
pbrew install: Pre-Flight-Check auf Build-Libraries

### DIFF
--- a/pbrew/cli/install.py
+++ b/pbrew/cli/install.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import click
 
-from pbrew.core import builder, config as cfg_mod, resolver, state as state_mod
+from pbrew.core import build_libs, builder, config as cfg_mod, resolver, state as state_mod
 from pbrew.core.paths import (
     build_log, cli_ini_dir, configs_dir, distfiles_dir,
     confd_dir, family_from_version, fpm_ini_dir, logs_dir,
@@ -22,8 +22,9 @@ from pbrew.utils.health import run_basic_checks
 @click.option("--config", "config_name", default=None, help="Benannte Config (z.B. production)")
 @click.option("--save", is_flag=True, help="Config nach dem Build speichern")
 @click.option("-j", "--jobs", type=int, default=None, help="Parallele Build-Jobs")
+@click.option("--skip-lib-check", is_flag=True, help="Überspringt den Pre-Flight-Check der Build-Libraries")
 @click.pass_context
-def install_cmd(ctx, version_spec, config_name, save, jobs):
+def install_cmd(ctx, version_spec, config_name, save, jobs, skip_lib_check):
     """PHP aus dem Quellcode bauen und installieren."""
     prefix: Path = ctx.obj["prefix"]
     family = family_from_version(version_spec)
@@ -46,6 +47,9 @@ def install_cmd(ctx, version_spec, config_name, save, jobs):
     if save and config_name:
         cfg_mod.save_config(cfgs_dir, config_name, config)
         click.echo(f"  Config als '{config_name}' gespeichert.")
+
+    if not skip_lib_check:
+        _check_build_libraries(config.get("build", {}).get("variants", []))
 
     dist_dir = distfiles_dir(prefix)
     tarball = dist_dir / f"php-{version}.tar.bz2"
@@ -113,6 +117,30 @@ def install_cmd(ctx, version_spec, config_name, save, jobs):
         click.echo("  Warnung: Einige Checks fehlgeschlagen. Log: " + str(log_path), err=True)
 
     click.echo(f"✓ PHP {version} installiert.")
+
+
+def _check_build_libraries(variants: list[str]) -> None:
+    """Pre-Flight-Check: bricht ab, wenn Dev-Libs fehlen, mit Installationshinweis."""
+    missing = build_libs.check_required_libs(variants)
+    if not missing:
+        return
+
+    click.echo("\n  Pre-Flight-Check: fehlende Build-Libraries", err=True)
+    for m in missing:
+        scope = "Pflicht" if m.variant == "core" else f"für {m.variant}"
+        pkg_hint = f" → {m.distro_pkg}" if m.distro_pkg else ""
+        click.echo(f"    ✗ {m.pkgconfig} ({scope}){pkg_hint}", err=True)
+
+    cmd = build_libs.install_command(missing)
+    if cmd:
+        click.echo(f"\n  Installation:\n    {cmd}", err=True)
+    else:
+        click.echo(
+            "\n  Bitte die Dev-Pakete für die obigen pkg-config-Namen installieren.",
+            err=True,
+        )
+    click.echo("\n  Mit --skip-lib-check kann diese Prüfung übersprungen werden.\n", err=True)
+    sys.exit(1)
 
 
 def _run_phase(name: str, action, build_dir: Path, log_path: Path) -> None:

--- a/pbrew/core/build_libs.py
+++ b/pbrew/core/build_libs.py
@@ -1,0 +1,108 @@
+"""Pre-Flight-Check für Build-Libraries.
+
+Prüft vor dem PHP-Build, ob alle nötigen Dev-Libraries installiert sind, indem
+pkg-config befragt wird. Liefert eine Liste fehlender Libs mit dem passenden
+Distro-Installationsbefehl.
+"""
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+from pbrew.core.prerequisites import detect_package_manager
+
+
+# Variant → pkg-config-Paketname.
+# Variants ohne Eintrag (z.B. bcmath, sockets) brauchen keine externe Lib.
+VARIANT_PKGCONFIG: dict[str, str] = {
+    "openssl":      "openssl",
+    "intl":         "icu-uc",
+    "soap":         "libxml-2.0",
+    "curl":         "libcurl",
+    "zip":          "libzip",
+    "sqlite":       "sqlite3",
+    "pgsql":        "libpq",
+    "fpm-systemd":  "libsystemd",
+    "zlib":         "zlib",
+}
+
+# PHP 8.x braucht das immer (unabhängig von Variants):
+#   libxml-2.0  → für XML-Parser im Core
+#   sqlite3     → bundled SQLite3-Extension seit PHP 7.4
+ALWAYS_REQUIRED: dict[str, str] = {
+    "libxml-2.0":   "core",
+    "sqlite3":      "core",
+}
+
+# pkg-config-Name → Distro-Paketname pro Paketmanager
+DISTRO_PACKAGES: dict[str, dict[str, str]] = {
+    "openssl":      {"apt-get": "libssl-dev",       "dnf": "openssl-devel",    "brew": "openssl"},
+    "icu-uc":       {"apt-get": "libicu-dev",       "dnf": "libicu-devel",     "brew": "icu4c"},
+    "libxml-2.0":   {"apt-get": "libxml2-dev",      "dnf": "libxml2-devel",    "brew": "libxml2"},
+    "libcurl":      {"apt-get": "libcurl4-openssl-dev", "dnf": "libcurl-devel", "brew": "curl"},
+    "libzip":       {"apt-get": "libzip-dev",       "dnf": "libzip-devel",     "brew": "libzip"},
+    "sqlite3":      {"apt-get": "libsqlite3-dev",   "dnf": "sqlite-devel",     "brew": "sqlite"},
+    "libpq":        {"apt-get": "libpq-dev",        "dnf": "postgresql-devel", "brew": "postgresql"},
+    "libsystemd":   {"apt-get": "libsystemd-dev",   "dnf": "systemd-devel",    "brew": ""},
+    "zlib":         {"apt-get": "zlib1g-dev",       "dnf": "zlib-devel",       "brew": "zlib"},
+}
+
+
+@dataclass
+class MissingLib:
+    pkgconfig: str
+    variant: str           # "core" für ALWAYS_REQUIRED
+    distro_pkg: "str | None"
+
+
+def check_required_libs(variants: list[str]) -> list[MissingLib]:
+    """Prüft, ob alle für die Variants benötigten pkg-config-Pakete da sind."""
+    if not shutil.which("pkg-config"):
+        return []  # Ohne pkg-config keine zuverlässige Aussage – kein false-positive
+
+    needed: list[tuple[str, str]] = list(ALWAYS_REQUIRED.items())
+    for variant in variants:
+        pkg = VARIANT_PKGCONFIG.get(variant)
+        if pkg:
+            needed.append((pkg, variant))
+
+    seen: set[str] = set()
+    pm = detect_package_manager()
+    missing: list[MissingLib] = []
+    for pkg, source in needed:
+        if pkg in seen:
+            continue
+        seen.add(pkg)
+        if not _pkg_config_exists(pkg):
+            distro_pkg = DISTRO_PACKAGES.get(pkg, {}).get(pm) if pm else None
+            missing.append(MissingLib(pkgconfig=pkg, variant=source, distro_pkg=distro_pkg or None))
+    return missing
+
+
+def install_command(missing: list[MissingLib]) -> "str | None":
+    """Liefert den Installationsbefehl für alle bekannten Distro-Pakete (oder None)."""
+    pm = detect_package_manager()
+    if not pm:
+        return None
+    pkgs = sorted({m.distro_pkg for m in missing if m.distro_pkg})
+    if not pkgs:
+        return None
+    pkg_str = " ".join(pkgs)
+    if pm == "apt-get":
+        return f"sudo apt install -y {pkg_str}"
+    if pm == "dnf":
+        return f"sudo dnf install -y {pkg_str}"
+    if pm == "brew":
+        return f"brew install {pkg_str}"
+    return None
+
+
+def _pkg_config_exists(pkg: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["pkg-config", "--exists", pkg],
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False

--- a/tests/test_build_libs.py
+++ b/tests/test_build_libs.py
@@ -1,0 +1,162 @@
+from unittest.mock import patch
+from pbrew.core.build_libs import (
+    MissingLib,
+    check_required_libs,
+    install_command,
+    VARIANT_PKGCONFIG,
+)
+
+
+# ---------------------------------------------------------------------------
+# check_required_libs
+# ---------------------------------------------------------------------------
+
+def test_check_returns_empty_when_all_present():
+    """Alle pkg-config-Calls liefern 0 → keine fehlende Lib."""
+    with patch("pbrew.core.build_libs._pkg_config_exists", return_value=True), \
+         patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
+        missing = check_required_libs(["openssl", "intl"])
+    assert missing == []
+
+
+def test_check_finds_missing_variant_lib():
+    """Variant intl ohne icu-uc → muss als fehlend gemeldet werden."""
+    def fake_exists(pkg):
+        return pkg != "icu-uc"
+    with patch("pbrew.core.build_libs._pkg_config_exists", side_effect=fake_exists), \
+         patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
+        missing = check_required_libs(["intl"])
+    assert any(m.pkgconfig == "icu-uc" for m in missing)
+    assert any(m.variant == "intl" for m in missing)
+
+
+def test_check_includes_always_required_libs():
+    """libxml-2.0 und sqlite3 sind unabhängig von Variants Pflicht."""
+    with patch("pbrew.core.build_libs._pkg_config_exists", return_value=False), \
+         patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
+        missing = check_required_libs([])
+    pkgs = {m.pkgconfig for m in missing}
+    assert "libxml-2.0" in pkgs
+    assert "sqlite3" in pkgs
+
+
+def test_check_skips_unknown_variants():
+    """Variants ohne pkg-config-Mapping (z.B. bcmath) verursachen keinen Fehler."""
+    with patch("pbrew.core.build_libs._pkg_config_exists", return_value=True), \
+         patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
+        missing = check_required_libs(["bcmath", "sockets", "exif"])
+    assert missing == []
+
+
+def test_check_returns_empty_when_pkg_config_not_installed():
+    """Ohne pkg-config selbst können wir nichts prüfen – keine false-positives."""
+    with patch("pbrew.core.build_libs.shutil.which", return_value=None):
+        missing = check_required_libs(["openssl", "intl"])
+    assert missing == []
+
+
+def test_check_dedups_libs_referenced_by_multiple_variants():
+    """libxml-2.0 ist core + (theoretisch auch von soap) → nur einmal gemeldet."""
+    with patch("pbrew.core.build_libs._pkg_config_exists", return_value=False), \
+         patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
+        missing = check_required_libs(["soap"])
+    libxml_entries = [m for m in missing if m.pkgconfig == "libxml-2.0"]
+    assert len(libxml_entries) == 1
+
+
+# ---------------------------------------------------------------------------
+# install_command
+# ---------------------------------------------------------------------------
+
+def test_install_command_apt():
+    missing = [
+        MissingLib(pkgconfig="icu-uc", variant="intl", distro_pkg="libicu-dev"),
+        MissingLib(pkgconfig="openssl", variant="openssl", distro_pkg="libssl-dev"),
+    ]
+    with patch("pbrew.core.build_libs.detect_package_manager", return_value="apt-get"):
+        cmd = install_command(missing)
+    assert cmd is not None
+    assert "apt install" in cmd
+    assert "libicu-dev" in cmd
+    assert "libssl-dev" in cmd
+
+
+def test_install_command_returns_none_without_pm():
+    missing = [MissingLib(pkgconfig="x", variant="y", distro_pkg="z")]
+    with patch("pbrew.core.build_libs.detect_package_manager", return_value=None):
+        assert install_command(missing) is None
+
+
+def test_install_command_skips_libs_without_distro_package():
+    """Eine Lib ohne bekanntes Distro-Paket darf den Befehl nicht zerstören."""
+    missing = [
+        MissingLib(pkgconfig="x", variant="y", distro_pkg=None),
+        MissingLib(pkgconfig="openssl", variant="openssl", distro_pkg="libssl-dev"),
+    ]
+    with patch("pbrew.core.build_libs.detect_package_manager", return_value="apt-get"):
+        cmd = install_command(missing)
+    assert "libssl-dev" in cmd
+    assert "None" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# Mapping-Konsistenz
+# ---------------------------------------------------------------------------
+
+def test_all_mapped_variants_appear_in_builder_variant_flags():
+    """Jedes Variant aus VARIANT_PKGCONFIG muss auch im Builder bekannt sein."""
+    from pbrew.core.builder import _VARIANT_FLAGS
+    for variant in VARIANT_PKGCONFIG:
+        assert variant in _VARIANT_FLAGS, f"{variant} fehlt in builder._VARIANT_FLAGS"
+
+
+# ---------------------------------------------------------------------------
+# install_cmd-Integration
+# ---------------------------------------------------------------------------
+
+def test_install_aborts_on_missing_libs(tmp_path):
+    """install bricht ab, wenn Pre-Flight-Libs fehlen, mit Installationshinweis."""
+    import os
+    from click.testing import CliRunner
+    from pbrew.cli import main
+    from pbrew.core.resolver import PhpRelease
+
+    release = PhpRelease(version="8.4.22", family="8.4",
+                         tarball_url="x", sha256="y")
+    fake_missing = [MissingLib(pkgconfig="icu-uc", variant="intl", distro_pkg="libicu-dev")]
+
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}), \
+         patch("pbrew.cli.install.resolver.fetch_latest", return_value=release), \
+         patch("pbrew.cli.install.build_libs.check_required_libs", return_value=fake_missing), \
+         patch("pbrew.cli.install.build_libs.install_command", return_value="sudo apt install -y libicu-dev"):
+        result = runner.invoke(main, ["--prefix", str(tmp_path / "pbrew"), "install", "8.4"])
+
+    assert result.exit_code != 0
+    assert "icu-uc" in result.output
+    assert "libicu-dev" in result.output
+    assert "--skip-lib-check" in result.output
+
+
+def test_install_skips_lib_check_with_flag(tmp_path):
+    """--skip-lib-check überspringt den Check komplett."""
+    import os
+    from click.testing import CliRunner
+    from pbrew.cli import main
+    from pbrew.core.resolver import PhpRelease
+
+    release = PhpRelease(version="8.4.22", family="8.4",
+                         tarball_url="x", sha256="y")
+    fake_missing = [MissingLib(pkgconfig="icu-uc", variant="intl", distro_pkg="libicu-dev")]
+
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}), \
+         patch("pbrew.cli.install.resolver.fetch_latest", return_value=release), \
+         patch("pbrew.cli.install.build_libs.check_required_libs", return_value=fake_missing) as mock_check, \
+         patch("pbrew.cli.install.dl_mod.download", side_effect=RuntimeError("download blockt")):
+        result = runner.invoke(main, ["--prefix", str(tmp_path / "pbrew"), "install", "8.4", "--skip-lib-check"])
+
+    # Check darf nicht aufgerufen worden sein
+    mock_check.assert_not_called()
+    # Wir scheitern stattdessen am Download (das ist OK – beweist, dass der Check übersprungen wurde)
+    assert "icu-uc" not in result.output


### PR DESCRIPTION
## Summary

Statt erst nach 48s während \`configure\` zu scheitern, prüft \`pbrew install\` jetzt **vor** dem Build, ob alle nötigen Dev-Libraries installiert sind, und gibt den passenden Installationsbefehl aus.

### Vorher

\`\`\`
  → configure... ✗ (48s)
  Fehler in Phase 'configure' nach 48s
  configure: error: Package requirements (icu-uc >= 50.1) were not met
\`\`\`

### Nachher

\`\`\`
  Pre-Flight-Check: fehlende Build-Libraries
    ✗ icu-uc (für intl) → libicu-dev
    ✗ libxml-2.0 (Pflicht) → libxml2-dev

  Installation:
    sudo apt install -y libicu-dev libxml2-dev

  Mit --skip-lib-check kann diese Prüfung übersprungen werden.
\`\`\`

### Mappings

- \`VARIANT_PKGCONFIG\`: variant → pkg-config-Name (openssl/intl/soap/curl/zip/sqlite/pgsql/fpm-systemd/zlib)
- \`ALWAYS_REQUIRED\`: PHP 8.x-Pflicht (libxml-2.0, sqlite3)
- \`DISTRO_PACKAGES\`: pkg-config → apt/dnf/brew-Paketname

### Robustheit

- Ohne \`pkg-config\` selbst → kein Check (kein false-positive)
- Variants ohne pkg-config-Mapping (bcmath, sockets, exif) werden ignoriert
- Konsistenz-Test stellt sicher, dass jedes geprüfte Variant auch im Builder existiert
- 12 neue Tests

Closes #36