### PR TITLE
Pre-Flight-Check: Header-Fallback für libtidy, libbz2, libreadline

### DIFF
--- a/pbrew/cli/install.py
+++ b/pbrew/cli/install.py
@@ -129,7 +129,7 @@ def _check_build_libraries(variants: list[str]) -> None:
     for m in missing:
         scope = "Pflicht" if m.variant == "core" else f"für {m.variant}"
         pkg_hint = f" → {m.distro_pkg}" if m.distro_pkg else ""
-        click.echo(f"    ✗ {m.pkgconfig} ({scope}){pkg_hint}", err=True)
+        click.echo(f"    ✗ {m.name} ({scope}){pkg_hint}", err=True)
 
     cmd = build_libs.install_command(missing)
     if cmd:

--- a/pbrew/core/build_libs.py
+++ b/pbrew/core/build_libs.py
@@ -1,19 +1,56 @@
 """Pre-Flight-Check für Build-Libraries.
 
-Prüft vor dem PHP-Build, ob alle nötigen Dev-Libraries installiert sind, indem
-pkg-config befragt wird. Liefert eine Liste fehlender Libs mit dem passenden
-Distro-Installationsbefehl.
+Prüft vor dem PHP-Build, ob alle nötigen Dev-Libraries installiert sind.
+Strategie pro Lib: erst pkg-config, dann Header-Fallback (für Libs ohne
+verlässlichen .pc-File wie bz2 oder readline).
 """
 import shutil
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from pathlib import Path
 
 from pbrew.core.prerequisites import detect_package_manager
 
 
-# Variant → pkg-config-Paketname.
-# Variants ohne Eintrag (z.B. bcmath, sockets) brauchen keine externe Lib.
-VARIANT_PKGCONFIG: dict[str, str] = {
+@dataclass(frozen=True)
+class LibCheck:
+    """Wie eine Build-Library auf System-Verfügbarkeit geprüft wird."""
+    pkgconfig: "str | None" = None
+    headers: tuple[str, ...] = field(default_factory=tuple)
+
+
+# Lib-ID → Prüfstrategie.
+# Die Lib-ID ist der Schlüssel, über den DISTRO_PACKAGES gemappt werden.
+LIB_CHECKS: dict[str, LibCheck] = {
+    # pkg-config verfügbar
+    "openssl":      LibCheck(pkgconfig="openssl"),
+    "icu-uc":       LibCheck(pkgconfig="icu-uc"),
+    "libxml-2.0":   LibCheck(pkgconfig="libxml-2.0"),
+    "libcurl":      LibCheck(pkgconfig="libcurl"),
+    "libzip":       LibCheck(pkgconfig="libzip"),
+    "sqlite3":      LibCheck(pkgconfig="sqlite3"),
+    "libpq":        LibCheck(pkgconfig="libpq"),
+    "libsystemd":   LibCheck(pkgconfig="libsystemd"),
+    "zlib":         LibCheck(pkgconfig="zlib"),
+    # pkg-config + Header-Fallback (je nach Distro unzuverlässig)
+    "tidy":         LibCheck(
+        pkgconfig="tidy",
+        headers=("/usr/include/tidy.h", "/usr/include/tidy/tidy.h"),
+    ),
+    # Nur Header (keine .pc-Files im Upstream-Projekt)
+    "bz2":          LibCheck(
+        headers=("/usr/include/bzlib.h",),
+    ),
+    "readline":     LibCheck(
+        headers=(
+            "/usr/include/readline/readline.h",
+            "/usr/include/x86_64-linux-gnu/readline/readline.h",
+        ),
+    ),
+}
+
+# Variant-Name → Lib-ID
+VARIANT_LIB: dict[str, str] = {
     "openssl":      "openssl",
     "intl":         "icu-uc",
     "soap":         "libxml-2.0",
@@ -23,6 +60,9 @@ VARIANT_PKGCONFIG: dict[str, str] = {
     "pgsql":        "libpq",
     "fpm-systemd":  "libsystemd",
     "zlib":         "zlib",
+    "tidy":         "tidy",
+    "bz2":          "bz2",
+    "readline":     "readline",
 }
 
 # PHP 8.x braucht das immer (unabhängig von Variants):
@@ -33,49 +73,67 @@ ALWAYS_REQUIRED: dict[str, str] = {
     "sqlite3":      "core",
 }
 
-# pkg-config-Name → Distro-Paketname pro Paketmanager
+# Lib-ID → Distro-Paketname pro Paketmanager
 DISTRO_PACKAGES: dict[str, dict[str, str]] = {
-    "openssl":      {"apt-get": "libssl-dev",       "dnf": "openssl-devel",    "brew": "openssl"},
-    "icu-uc":       {"apt-get": "libicu-dev",       "dnf": "libicu-devel",     "brew": "icu4c"},
-    "libxml-2.0":   {"apt-get": "libxml2-dev",      "dnf": "libxml2-devel",    "brew": "libxml2"},
-    "libcurl":      {"apt-get": "libcurl4-openssl-dev", "dnf": "libcurl-devel", "brew": "curl"},
-    "libzip":       {"apt-get": "libzip-dev",       "dnf": "libzip-devel",     "brew": "libzip"},
-    "sqlite3":      {"apt-get": "libsqlite3-dev",   "dnf": "sqlite-devel",     "brew": "sqlite"},
-    "libpq":        {"apt-get": "libpq-dev",        "dnf": "postgresql-devel", "brew": "postgresql"},
-    "libsystemd":   {"apt-get": "libsystemd-dev",   "dnf": "systemd-devel",    "brew": ""},
-    "zlib":         {"apt-get": "zlib1g-dev",       "dnf": "zlib-devel",       "brew": "zlib"},
+    "openssl":      {"apt-get": "libssl-dev",           "dnf": "openssl-devel",     "brew": "openssl"},
+    "icu-uc":       {"apt-get": "libicu-dev",           "dnf": "libicu-devel",      "brew": "icu4c"},
+    "libxml-2.0":   {"apt-get": "libxml2-dev",          "dnf": "libxml2-devel",     "brew": "libxml2"},
+    "libcurl":      {"apt-get": "libcurl4-openssl-dev", "dnf": "libcurl-devel",     "brew": "curl"},
+    "libzip":       {"apt-get": "libzip-dev",           "dnf": "libzip-devel",      "brew": "libzip"},
+    "sqlite3":      {"apt-get": "libsqlite3-dev",       "dnf": "sqlite-devel",      "brew": "sqlite"},
+    "libpq":        {"apt-get": "libpq-dev",            "dnf": "postgresql-devel",  "brew": "postgresql"},
+    "libsystemd":   {"apt-get": "libsystemd-dev",       "dnf": "systemd-devel"},
+    "zlib":         {"apt-get": "zlib1g-dev",           "dnf": "zlib-devel",        "brew": "zlib"},
+    "tidy":         {"apt-get": "libtidy-dev",          "dnf": "libtidy-devel",     "brew": "tidy-html5"},
+    "bz2":          {"apt-get": "libbz2-dev",           "dnf": "bzip2-devel",       "brew": "bzip2"},
+    "readline":     {"apt-get": "libreadline-dev",      "dnf": "readline-devel",    "brew": "readline"},
 }
 
 
 @dataclass
 class MissingLib:
-    pkgconfig: str
-    variant: str           # "core" für ALWAYS_REQUIRED
+    name: str                   # Lib-ID aus LIB_CHECKS
+    variant: str                # "core" für ALWAYS_REQUIRED
     distro_pkg: "str | None"
 
 
 def check_required_libs(variants: list[str]) -> list[MissingLib]:
-    """Prüft, ob alle für die Variants benötigten pkg-config-Pakete da sind."""
+    """Prüft, ob alle für die Variants benötigten Libs da sind."""
+    # Ohne pkg-config können wir pkg-config-basierte Libs nicht prüfen → kein Check.
+    # Header-only-Libs würden zwar funktionieren, aber das ist inkonsistent – lieber gar nichts melden.
     if not shutil.which("pkg-config"):
-        return []  # Ohne pkg-config keine zuverlässige Aussage – kein false-positive
+        return []
 
     needed: list[tuple[str, str]] = list(ALWAYS_REQUIRED.items())
     for variant in variants:
-        pkg = VARIANT_PKGCONFIG.get(variant)
-        if pkg:
-            needed.append((pkg, variant))
+        lib_id = VARIANT_LIB.get(variant)
+        if lib_id:
+            needed.append((lib_id, variant))
 
     seen: set[str] = set()
     pm = detect_package_manager()
     missing: list[MissingLib] = []
-    for pkg, source in needed:
-        if pkg in seen:
+    for lib_id, source in needed:
+        if lib_id in seen:
             continue
-        seen.add(pkg)
-        if not _pkg_config_exists(pkg):
-            distro_pkg = DISTRO_PACKAGES.get(pkg, {}).get(pm) if pm else None
-            missing.append(MissingLib(pkgconfig=pkg, variant=source, distro_pkg=distro_pkg or None))
+        seen.add(lib_id)
+        if _lib_available(lib_id):
+            continue
+        distro_pkg = DISTRO_PACKAGES.get(lib_id, {}).get(pm) if pm else None
+        missing.append(MissingLib(name=lib_id, variant=source, distro_pkg=distro_pkg or None))
     return missing
+
+
+def _lib_available(lib_id: str) -> bool:
+    """Prüft Lib per pkg-config (wenn definiert) UND/ODER Header-Fallback."""
+    check = LIB_CHECKS.get(lib_id)
+    if check is None:
+        return True  # Unbekannte Libs nicht als fehlend melden
+    if check.pkgconfig and _pkg_config_exists(check.pkgconfig):
+        return True
+    if check.headers and _headers_exist(check.headers):
+        return True
+    return False
 
 
 def install_command(missing: list[MissingLib]) -> "str | None":
@@ -106,3 +164,8 @@ def _pkg_config_exists(pkg: str) -> bool:
         return result.returncode == 0
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
+
+
+def _headers_exist(paths: tuple[str, ...]) -> bool:
+    """True wenn mindestens eine der Header-Dateien existiert."""
+    return any(Path(p).exists() for p in paths)

--- a/tests/test_build_libs.py
+++ b/tests/test_build_libs.py
@@ -3,65 +3,135 @@ from pbrew.core.build_libs import (
     MissingLib,
     check_required_libs,
     install_command,
-    VARIANT_PKGCONFIG,
+    LibCheck,
+    LIB_CHECKS,
+    VARIANT_LIB,
 )
 
 
 # ---------------------------------------------------------------------------
-# check_required_libs
+# check_required_libs – pkg-config-Pfad
 # ---------------------------------------------------------------------------
 
 def test_check_returns_empty_when_all_present():
-    """Alle pkg-config-Calls liefern 0 → keine fehlende Lib."""
     with patch("pbrew.core.build_libs._pkg_config_exists", return_value=True), \
+         patch("pbrew.core.build_libs._headers_exist", return_value=True), \
          patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
         missing = check_required_libs(["openssl", "intl"])
     assert missing == []
 
 
 def test_check_finds_missing_variant_lib():
-    """Variant intl ohne icu-uc → muss als fehlend gemeldet werden."""
-    def fake_exists(pkg):
+    def fake_pkg(pkg):
         return pkg != "icu-uc"
-    with patch("pbrew.core.build_libs._pkg_config_exists", side_effect=fake_exists), \
+    with patch("pbrew.core.build_libs._pkg_config_exists", side_effect=fake_pkg), \
+         patch("pbrew.core.build_libs._headers_exist", return_value=False), \
          patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
         missing = check_required_libs(["intl"])
-    assert any(m.pkgconfig == "icu-uc" for m in missing)
+    assert any(m.name == "icu-uc" for m in missing)
     assert any(m.variant == "intl" for m in missing)
 
 
 def test_check_includes_always_required_libs():
-    """libxml-2.0 und sqlite3 sind unabhängig von Variants Pflicht."""
     with patch("pbrew.core.build_libs._pkg_config_exists", return_value=False), \
+         patch("pbrew.core.build_libs._headers_exist", return_value=False), \
          patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
         missing = check_required_libs([])
-    pkgs = {m.pkgconfig for m in missing}
-    assert "libxml-2.0" in pkgs
-    assert "sqlite3" in pkgs
+    names = {m.name for m in missing}
+    assert "libxml-2.0" in names
+    assert "sqlite3" in names
 
 
 def test_check_skips_unknown_variants():
-    """Variants ohne pkg-config-Mapping (z.B. bcmath) verursachen keinen Fehler."""
     with patch("pbrew.core.build_libs._pkg_config_exists", return_value=True), \
+         patch("pbrew.core.build_libs._headers_exist", return_value=True), \
          patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
         missing = check_required_libs(["bcmath", "sockets", "exif"])
     assert missing == []
 
 
 def test_check_returns_empty_when_pkg_config_not_installed():
-    """Ohne pkg-config selbst können wir nichts prüfen – keine false-positives."""
+    """Ohne pkg-config selbst: keine Prüfung (kein false-positive)."""
     with patch("pbrew.core.build_libs.shutil.which", return_value=None):
         missing = check_required_libs(["openssl", "intl"])
     assert missing == []
 
 
 def test_check_dedups_libs_referenced_by_multiple_variants():
-    """libxml-2.0 ist core + (theoretisch auch von soap) → nur einmal gemeldet."""
     with patch("pbrew.core.build_libs._pkg_config_exists", return_value=False), \
+         patch("pbrew.core.build_libs._headers_exist", return_value=False), \
          patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
         missing = check_required_libs(["soap"])
-    libxml_entries = [m for m in missing if m.pkgconfig == "libxml-2.0"]
+    libxml_entries = [m for m in missing if m.name == "libxml-2.0"]
     assert len(libxml_entries) == 1
+
+
+# ---------------------------------------------------------------------------
+# Header-Fallback für Libs ohne pkg-config (#39)
+# ---------------------------------------------------------------------------
+
+def test_bz2_detected_via_header(tmp_path):
+    """bz2 hat kein pkg-config – muss per Header gefunden werden."""
+    header = tmp_path / "bzlib.h"
+    header.write_text("")
+    # Patch LIB_CHECKS für bz2: benutze das tmp_path-Header
+    patched_checks = dict(LIB_CHECKS)
+    patched_checks["bz2"] = LibCheck(headers=(str(header),))
+    with patch("pbrew.core.build_libs._pkg_config_exists", return_value=True), \
+         patch("pbrew.core.build_libs.LIB_CHECKS", patched_checks), \
+         patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
+        missing = check_required_libs(["bz2"])
+    assert not any(m.name == "bz2" for m in missing)
+
+
+def test_bz2_missing_when_no_header(tmp_path):
+    """Header existiert nicht → bz2 fehlt."""
+    patched_checks = dict(LIB_CHECKS)
+    patched_checks["bz2"] = LibCheck(headers=(str(tmp_path / "nonexistent.h"),))
+    with patch("pbrew.core.build_libs._pkg_config_exists", return_value=True), \
+         patch("pbrew.core.build_libs.LIB_CHECKS", patched_checks), \
+         patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
+        missing = check_required_libs(["bz2"])
+    assert any(m.name == "bz2" for m in missing)
+
+
+def test_tidy_found_via_pkgconfig_only():
+    """tidy hat pkg-config + Header-Fallback. pkg-config reicht allein."""
+    with patch("pbrew.core.build_libs._pkg_config_exists", return_value=True), \
+         patch("pbrew.core.build_libs._headers_exist", return_value=False), \
+         patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
+        missing = check_required_libs(["tidy"])
+    assert not any(m.name == "tidy" for m in missing)
+
+
+def test_tidy_found_via_header_fallback():
+    """tidy ohne pkg-config aber mit Header → nicht als fehlend melden."""
+    def fake_pkg(pkg):
+        return pkg != "tidy"  # tidy.pc fehlt auf dieser Distro
+    with patch("pbrew.core.build_libs._pkg_config_exists", side_effect=fake_pkg), \
+         patch("pbrew.core.build_libs._headers_exist", return_value=True), \
+         patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
+        missing = check_required_libs(["tidy"])
+    assert not any(m.name == "tidy" for m in missing)
+
+
+def test_tidy_missing_when_no_pkgconfig_and_no_header():
+    with patch("pbrew.core.build_libs._pkg_config_exists", return_value=False), \
+         patch("pbrew.core.build_libs._headers_exist", return_value=False), \
+         patch("pbrew.core.build_libs.shutil.which", return_value="/usr/bin/pkg-config"):
+        missing = check_required_libs(["tidy"])
+    assert any(m.name == "tidy" for m in missing)
+
+
+def test_readline_uses_headers_only():
+    """readline hat kein pkg-config, nur Header."""
+    assert LIB_CHECKS["readline"].pkgconfig is None
+    assert LIB_CHECKS["readline"].headers
+
+
+def test_bz2_uses_headers_only():
+    assert LIB_CHECKS["bz2"].pkgconfig is None
+    assert LIB_CHECKS["bz2"].headers
 
 
 # ---------------------------------------------------------------------------
@@ -70,8 +140,8 @@ def test_check_dedups_libs_referenced_by_multiple_variants():
 
 def test_install_command_apt():
     missing = [
-        MissingLib(pkgconfig="icu-uc", variant="intl", distro_pkg="libicu-dev"),
-        MissingLib(pkgconfig="openssl", variant="openssl", distro_pkg="libssl-dev"),
+        MissingLib(name="icu-uc", variant="intl", distro_pkg="libicu-dev"),
+        MissingLib(name="openssl", variant="openssl", distro_pkg="libssl-dev"),
     ]
     with patch("pbrew.core.build_libs.detect_package_manager", return_value="apt-get"):
         cmd = install_command(missing)
@@ -82,16 +152,15 @@ def test_install_command_apt():
 
 
 def test_install_command_returns_none_without_pm():
-    missing = [MissingLib(pkgconfig="x", variant="y", distro_pkg="z")]
+    missing = [MissingLib(name="x", variant="y", distro_pkg="z")]
     with patch("pbrew.core.build_libs.detect_package_manager", return_value=None):
         assert install_command(missing) is None
 
 
 def test_install_command_skips_libs_without_distro_package():
-    """Eine Lib ohne bekanntes Distro-Paket darf den Befehl nicht zerstören."""
     missing = [
-        MissingLib(pkgconfig="x", variant="y", distro_pkg=None),
-        MissingLib(pkgconfig="openssl", variant="openssl", distro_pkg="libssl-dev"),
+        MissingLib(name="x", variant="y", distro_pkg=None),
+        MissingLib(name="openssl", variant="openssl", distro_pkg="libssl-dev"),
     ]
     with patch("pbrew.core.build_libs.detect_package_manager", return_value="apt-get"):
         cmd = install_command(missing)
@@ -104,10 +173,16 @@ def test_install_command_skips_libs_without_distro_package():
 # ---------------------------------------------------------------------------
 
 def test_all_mapped_variants_appear_in_builder_variant_flags():
-    """Jedes Variant aus VARIANT_PKGCONFIG muss auch im Builder bekannt sein."""
+    """Jedes Variant aus VARIANT_LIB muss auch im Builder bekannt sein."""
     from pbrew.core.builder import _VARIANT_FLAGS
-    for variant in VARIANT_PKGCONFIG:
+    for variant in VARIANT_LIB:
         assert variant in _VARIANT_FLAGS, f"{variant} fehlt in builder._VARIANT_FLAGS"
+
+
+def test_every_variant_lib_has_a_check():
+    """Jede in VARIANT_LIB referenzierte Lib-ID hat einen Eintrag in LIB_CHECKS."""
+    for variant, lib_id in VARIANT_LIB.items():
+        assert lib_id in LIB_CHECKS, f"Lib-ID {lib_id!r} (via {variant}) fehlt in LIB_CHECKS"
 
 
 # ---------------------------------------------------------------------------
@@ -115,15 +190,13 @@ def test_all_mapped_variants_appear_in_builder_variant_flags():
 # ---------------------------------------------------------------------------
 
 def test_install_aborts_on_missing_libs(tmp_path):
-    """install bricht ab, wenn Pre-Flight-Libs fehlen, mit Installationshinweis."""
     import os
     from click.testing import CliRunner
     from pbrew.cli import main
     from pbrew.core.resolver import PhpRelease
 
-    release = PhpRelease(version="8.4.22", family="8.4",
-                         tarball_url="x", sha256="y")
-    fake_missing = [MissingLib(pkgconfig="icu-uc", variant="intl", distro_pkg="libicu-dev")]
+    release = PhpRelease(version="8.4.22", family="8.4", tarball_url="x", sha256="y")
+    fake_missing = [MissingLib(name="icu-uc", variant="intl", distro_pkg="libicu-dev")]
 
     runner = CliRunner()
     with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}), \
@@ -139,15 +212,13 @@ def test_install_aborts_on_missing_libs(tmp_path):
 
 
 def test_install_skips_lib_check_with_flag(tmp_path):
-    """--skip-lib-check überspringt den Check komplett."""
     import os
     from click.testing import CliRunner
     from pbrew.cli import main
     from pbrew.core.resolver import PhpRelease
 
-    release = PhpRelease(version="8.4.22", family="8.4",
-                         tarball_url="x", sha256="y")
-    fake_missing = [MissingLib(pkgconfig="icu-uc", variant="intl", distro_pkg="libicu-dev")]
+    release = PhpRelease(version="8.4.22", family="8.4", tarball_url="x", sha256="y")
+    fake_missing = [MissingLib(name="icu-uc", variant="intl", distro_pkg="libicu-dev")]
 
     runner = CliRunner()
     with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}), \
@@ -156,7 +227,5 @@ def test_install_skips_lib_check_with_flag(tmp_path):
          patch("pbrew.cli.install.dl_mod.download", side_effect=RuntimeError("download blockt")):
         result = runner.invoke(main, ["--prefix", str(tmp_path / "pbrew"), "install", "8.4", "--skip-lib-check"])
 
-    # Check darf nicht aufgerufen worden sein
     mock_check.assert_not_called()
-    # Wir scheitern stattdessen am Download (das ist OK – beweist, dass der Check übersprungen wurde)
     assert "icu-uc" not in result.output

--- a/tests/test_install_ux.py
+++ b/tests/test_install_ux.py
@@ -46,6 +46,7 @@ def _invoke_install(prefix, tmp_path, version="8.4.22"):
     env = {"XDG_CONFIG_HOME": str(tmp_path / "config")}
     with patch.dict(os.environ, env), \
          patch("pbrew.cli.install.resolver.fetch_latest", return_value=_make_release(version)), \
+         patch("pbrew.cli.install.build_libs.check_required_libs", return_value=[]), \
          patch("pbrew.cli.install.builder.run_configure", return_value=None) as mc, \
          patch("pbrew.cli.install.builder.run_make", return_value=None) as mm, \
          patch("pbrew.cli.install.builder.run_make_install",
@@ -98,6 +99,7 @@ def test_error_in_configure_reports_which_phase(tmp_path):
     env = {"XDG_CONFIG_HOME": str(tmp_path / "config")}
     with patch.dict(os.environ, env), \
          patch("pbrew.cli.install.resolver.fetch_latest", return_value=_make_release()), \
+         patch("pbrew.cli.install.build_libs.check_required_libs", return_value=[]), \
          patch("pbrew.cli.install.builder.run_configure",
                side_effect=RuntimeError("bison not found")):
         result = runner.invoke(main, ["--prefix", str(prefix), "install", "8.4"])


### PR DESCRIPTION
## Summary

Fängt jetzt auch \`configure: error: Cannot find libtidy\` **vor** dem Build ab.

### Problem

Das bisherige \`check_required_libs\` prüfte nur per pkg-config. Dabei rutschten durch:

- \`libtidy\` – pkg-config unzuverlässig je Distro
- \`libbz2\` – hat **nie** ein pkg-config
- \`libreadline\` – hat **nie** ein pkg-config

### Lösung

Refactor zu \`LibCheck(pkgconfig, headers)\`: pro Lib wird erst pkg-config probiert, dann als Fallback die Existenz gängiger Header-Dateien (\`/usr/include/tidy.h\`, \`/usr/include/bzlib.h\`, …).

### Neue Libs

| Lib | pkg-config | Header-Fallback | Distro (apt) |
|---|---|---|---|
| tidy | \`tidy\` | \`/usr/include/tidy.h\` | libtidy-dev |
| bz2 | – | \`/usr/include/bzlib.h\` | libbz2-dev |
| readline | – | \`/usr/include/readline/readline.h\` | libreadline-dev |

### Live-Verifikation auf diesem System

\`\`\`
  tidy            (für tidy       ) -> libtidy-dev
Installation: sudo apt install -y libtidy-dev
\`\`\`

### API

- \`MissingLib.pkgconfig\` → \`MissingLib.name\` (semantischer)
- Neuer \`LibCheck\`-Dataclass
- \`LIB_CHECKS\`, \`VARIANT_LIB\` ersetzen \`VARIANT_PKGCONFIG\`
- 7 neue Tests + 13 bestehende weiterhin grün

Closes #39