### PR TITLE
FPM Task 1: Pool-Config-Generator (pbrew/fpm/pools.py)

### DIFF
--- a/pbrew/fpm/pools.py
+++ b/pbrew/fpm/pools.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+
+def generate_pool_config(
+    user: str,
+    family: str,
+    prefix: Path,
+    debug: bool = False,
+    pool_defaults: "dict | None" = None,
+) -> str:
+    """Generiert den Inhalt einer FPM Pool-Config-Datei."""
+    suffix = family.replace(".", "")
+    debug_suffix = "d" if debug else ""
+    pool_name = f"{user}-debug" if debug else user
+    socket = f"/run/php/php{suffix}{debug_suffix}-{user}.sock"
+
+    defaults = {
+        "pm": "dynamic",
+        "pm_max_children": 5,
+        "pm_start_servers": 2,
+        "pm_min_spare_servers": 1,
+        "pm_max_spare_servers": 3,
+    }
+    if pool_defaults:
+        defaults.update(pool_defaults)
+
+    return (
+        f"; Pool {pool_name} — generiert von pbrew fpm pool add\n"
+        f"[{pool_name}]\n"
+        f"user = {user}\n"
+        f"group = {user}\n"
+        f"listen = {socket}\n"
+        f"listen.owner = {user}\n"
+        f"listen.group = www-data\n"
+        f"listen.mode = 0660\n"
+        f"pm = {defaults['pm']}\n"
+        f"pm.max_children = {defaults['pm_max_children']}\n"
+        f"pm.start_servers = {defaults['pm_start_servers']}\n"
+        f"pm.min_spare_servers = {defaults['pm_min_spare_servers']}\n"
+        f"pm.max_spare_servers = {defaults['pm_max_spare_servers']}\n"
+    )
+
+
+def pool_config_path(
+    prefix: Path,
+    family: str,
+    user: str,
+    debug: bool = False,
+) -> Path:
+    """Gibt den Pfad zur Pool-Config-Datei zurück."""
+    subdir = f"{family}d" if debug else family
+    return prefix / "etc" / "fpm" / subdir / "php-fpm.d" / f"{user}.conf"
+
+
+def write_pool_config(
+    prefix: Path,
+    user: str,
+    family: str,
+    debug: bool = False,
+    pool_defaults: "dict | None" = None,
+) -> Path:
+    """Schreibt Pool-Config. Überschreibt nicht, wenn bereits vorhanden."""
+    path = pool_config_path(prefix, family, user, debug)
+    if path.exists():
+        return path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(generate_pool_config(user, family, prefix, debug, pool_defaults))
+    return path

--- a/tests/test_pools.py
+++ b/tests/test_pools.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+from pbrew.fpm.pools import (
+    generate_pool_config,
+    pool_config_path,
+    write_pool_config,
+)
+
+PREFIX = Path("/opt/pbrew")
+
+
+def test_generate_pool_config_contains_user():
+    content = generate_pool_config("alice", "8.4", PREFIX)
+    assert "[alice]" in content
+    assert "user = alice" in content
+
+
+def test_generate_pool_config_socket_path():
+    content = generate_pool_config("alice", "8.4", PREFIX)
+    assert "php84-alice.sock" in content
+
+
+def test_generate_pool_config_debug_suffix():
+    content = generate_pool_config("alice", "8.4", PREFIX, debug=True)
+    assert "[alice-debug]" in content
+    assert "php84d-alice.sock" in content
+
+
+def test_generate_pool_config_custom_defaults():
+    content = generate_pool_config(
+        "alice", "8.4", PREFIX,
+        pool_defaults={"pm_max_children": 10},
+    )
+    assert "pm.max_children = 10" in content
+
+
+def test_pool_config_path_normal():
+    path = pool_config_path(PREFIX, "8.4", "alice")
+    assert path == PREFIX / "etc" / "fpm" / "8.4" / "php-fpm.d" / "alice.conf"
+
+
+def test_pool_config_path_debug():
+    path = pool_config_path(PREFIX, "8.4", "alice", debug=True)
+    assert path == PREFIX / "etc" / "fpm" / "8.4d" / "php-fpm.d" / "alice.conf"
+
+
+def test_write_pool_config_creates_file(tmp_path):
+    path = write_pool_config(tmp_path, "alice", "8.4")
+    assert path.exists()
+    assert "[alice]" in path.read_text()
+
+
+def test_write_pool_config_does_not_overwrite(tmp_path):
+    path = write_pool_config(tmp_path, "alice", "8.4")
+    path.write_text("custom content")
+    write_pool_config(tmp_path, "alice", "8.4")
+    assert path.read_text() == "custom content"


### PR DESCRIPTION
Setzt Task 1 aus Plan 2 um. Generiert PHP-FPM Pool-Configs mit Debug-Trennung (socket `php84-alice.sock` vs `php84d-alice.sock`). Idempotent – existierende Configs bleiben erhalten. 8 Tests grün. Closes #41