### PR TITLE
FPM Task 2: systemd-Service-Generator

### DIFF
--- a/pbrew/fpm/services.py
+++ b/pbrew/fpm/services.py
@@ -1,0 +1,69 @@
+import subprocess
+from pathlib import Path
+
+
+def service_name(family: str, debug: bool = False) -> str:
+    """Gibt den systemd-Service-Namen zurück, z.B. 'php84-fpm'."""
+    suffix = family.replace(".", "")
+    debug_suffix = "d" if debug else ""
+    return f"php{suffix}{debug_suffix}-fpm"
+
+
+def service_path(family: str, debug: bool = False) -> Path:
+    """Gibt den Pfad zur systemd Unit-Datei zurück."""
+    return Path("/etc/systemd/system") / f"{service_name(family, debug)}.service"
+
+
+def generate_fpm_service(
+    prefix: Path,
+    version: str,
+    family: str,
+    debug: bool = False,
+) -> str:
+    """Generiert den Inhalt einer systemd FPM Unit."""
+    desc_suffix = " (Xdebug)" if debug else ""
+    fpm_bin = prefix / "versions" / version / "sbin" / "php-fpm"
+    php_ini = prefix / "etc" / "fpm" / family / "php.ini"
+    fpm_conf_subdir = f"{family}d" if debug else family
+    fpm_conf = prefix / "etc" / "fpm" / fpm_conf_subdir / "php-fpm.conf"
+
+    env_block = ""
+    if debug:
+        scan_normal = prefix / "etc" / "conf.d" / family
+        scan_debug = prefix / "etc" / "conf.d" / f"{family}d"
+        env_block = f'Environment="PHP_INI_SCAN_DIR={scan_normal}:{scan_debug}"\n'
+
+    return (
+        f"[Unit]\n"
+        f"Description=PHP {version} FPM{desc_suffix} (pbrew)\n"
+        f"After=network.target\n"
+        f"\n"
+        f"[Service]\n"
+        f"Type=notify\n"
+        f"{env_block}"
+        f"ExecStart={fpm_bin} \\\n"
+        f"  --php-ini {php_ini} \\\n"
+        f"  --fpm-config {fpm_conf} \\\n"
+        f"  --nodaemonize\n"
+        f"ExecReload=/bin/kill -USR2 $MAINPID\n"
+        f"Restart=on-failure\n"
+        f"\n"
+        f"[Install]\n"
+        f"WantedBy=multi-user.target\n"
+    )
+
+
+def write_service(
+    prefix: Path,
+    version: str,
+    family: str,
+    debug: bool = False,
+) -> Path:
+    """Schreibt systemd Unit nach /etc/systemd/system/ (benötigt root)."""
+    path = service_path(family, debug)
+    path.write_text(generate_fpm_service(prefix, version, family, debug))
+    return path
+
+
+def reload_systemd() -> None:
+    subprocess.run(["sudo", "systemctl", "daemon-reload"], check=True)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+from pbrew.fpm.services import (
+    generate_fpm_service,
+    service_name,
+    service_path,
+)
+
+PREFIX = Path("/opt/pbrew")
+
+
+def test_service_name_normal():
+    assert service_name("8.4") == "php84-fpm"
+
+
+def test_service_name_debug():
+    assert service_name("8.4", debug=True) == "php84d-fpm"
+
+
+def test_service_path():
+    assert service_path("8.4") == Path("/etc/systemd/system/php84-fpm.service")
+
+
+def test_generate_fpm_service_contains_binary():
+    content = generate_fpm_service(PREFIX, "8.4.22", "8.4")
+    assert "/opt/pbrew/versions/8.4.22/sbin/php-fpm" in content
+
+
+def test_generate_fpm_service_contains_php_ini():
+    content = generate_fpm_service(PREFIX, "8.4.22", "8.4")
+    assert "--php-ini /opt/pbrew/etc/fpm/8.4/php.ini" in content
+
+
+def test_generate_fpm_service_contains_fpm_conf():
+    content = generate_fpm_service(PREFIX, "8.4.22", "8.4")
+    assert "--fpm-config /opt/pbrew/etc/fpm/8.4/php-fpm.conf" in content
+
+
+def test_generate_fpm_service_no_env_for_normal():
+    content = generate_fpm_service(PREFIX, "8.4.22", "8.4")
+    assert "PHP_INI_SCAN_DIR" not in content
+
+
+def test_generate_fpm_service_debug_has_scan_dir_env():
+    content = generate_fpm_service(PREFIX, "8.4.22", "8.4", debug=True)
+    assert "PHP_INI_SCAN_DIR" in content
+    assert "conf.d/8.4:" in content
+    assert "conf.d/8.4d" in content
+
+
+def test_generate_fpm_service_debug_uses_8_4d_conf():
+    content = generate_fpm_service(PREFIX, "8.4.22", "8.4", debug=True)
+    assert "fpm/8.4d/php-fpm.conf" in content
+
+
+def test_generate_fpm_service_is_type_notify():
+    content = generate_fpm_service(PREFIX, "8.4.22", "8.4")
+    assert "Type=notify" in content


### PR DESCRIPTION
Task 2 aus Plan 2. Generiert systemd-Units für php84-fpm (+ php84d-fpm bei debug). Debug-Unit mit zusätzlichem PHP_INI_SCAN_DIR-Env für getrennte Xdebug-INIs. Type=notify, Restart=on-failure. 10 Tests grün. Closes #43