### PR TITLE
FPM Task 3: Xdebug-Trennung + php84d-Wrapper

### DIFF
--- a/pbrew/fpm/xdebug.py
+++ b/pbrew/fpm/xdebug.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+
+def create_debug_wrapper(prefix: Path, version: str, family: str) -> Path:
+    """Erstellt php84d Wrapper-Script mit erweitertem PHP_INI_SCAN_DIR.
+
+    Xdebug wird nicht per `-n` (alle Extensions deaktivieren) getrennt,
+    sondern durch einen zweiten scan-dir (`conf.d/8.4d/`), der nur
+    `xdebug.ini` enthält. Der Wrapper setzt PHP_INI_SCAN_DIR auf beide.
+    So bleiben alle anderen Extensions aktiv – nur Xdebug kommt dazu.
+    """
+    suffix = family.replace(".", "")
+    scan_normal = prefix / "etc" / "conf.d" / family
+    scan_debug = prefix / "etc" / "conf.d" / f"{family}d"
+    php_bin = prefix / "versions" / version / "bin" / "php"
+
+    bdir = prefix / "bin"
+    bdir.mkdir(parents=True, exist_ok=True)
+    wrapper = bdir / f"php{suffix}d"
+    wrapper.write_text(
+        f'#!/bin/bash\n'
+        f'export PHP_INI_SCAN_DIR="{scan_normal}:{scan_debug}"\n'
+        f'exec {php_bin} "$@"\n'
+    )
+    wrapper.chmod(0o755)
+    return wrapper
+
+
+def create_xdebug_ini(prefix: Path, family: str) -> Path:
+    """Erstellt Platzhalter-xdebug.ini im Debug-scan-dir.
+
+    Die echte Extension wird via `pbrew ext install xdebug` gebaut.
+    Diese Datei stellt sicher, dass das Verzeichnis existiert und
+    dokumentiert den nächsten Schritt.
+    """
+    debug_dir = prefix / "etc" / "conf.d" / f"{family}d"
+    debug_dir.mkdir(parents=True, exist_ok=True)
+    ini = debug_dir / "xdebug.ini"
+    if ini.exists():
+        return ini
+    suffix = family.replace(".", "")
+    ini.write_text(
+        f"; Xdebug — nur in php{suffix}d verfügbar\n"
+        f"; Installieren: pbrew ext install xdebug {family}\n"
+        f"; zend_extension=xdebug.so\n"
+        f"; xdebug.mode=debug\n"
+        f"; xdebug.start_with_request=trigger\n"
+    )
+    return ini
+
+
+def debug_scan_dir(prefix: Path, family: str) -> str:
+    """Gibt den kombinierten PHP_INI_SCAN_DIR-Wert für den Debug-Wrapper zurück."""
+    scan_normal = prefix / "etc" / "conf.d" / family
+    scan_debug = prefix / "etc" / "conf.d" / f"{family}d"
+    return f"{scan_normal}:{scan_debug}"

--- a/tests/test_xdebug.py
+++ b/tests/test_xdebug.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from pbrew.fpm.xdebug import (
+    create_debug_wrapper,
+    create_xdebug_ini,
+    debug_scan_dir,
+)
+
+PREFIX = Path("/opt/pbrew")
+
+
+def test_create_debug_wrapper_creates_file(tmp_path):
+    wrapper = create_debug_wrapper(tmp_path, "8.4.22", "8.4")
+    assert wrapper.exists()
+    assert wrapper.name == "php84d"
+
+
+def test_create_debug_wrapper_is_executable(tmp_path):
+    wrapper = create_debug_wrapper(tmp_path, "8.4.22", "8.4")
+    assert wrapper.stat().st_mode & 0o111
+
+
+def test_create_debug_wrapper_sets_scan_dir(tmp_path):
+    wrapper = create_debug_wrapper(tmp_path, "8.4.22", "8.4")
+    content = wrapper.read_text()
+    assert "PHP_INI_SCAN_DIR" in content
+    assert "conf.d/8.4:" in content
+    assert "conf.d/8.4d" in content
+
+
+def test_create_debug_wrapper_execs_php_bin(tmp_path):
+    wrapper = create_debug_wrapper(tmp_path, "8.4.22", "8.4")
+    content = wrapper.read_text()
+    assert "versions/8.4.22/bin/php" in content
+    assert '"$@"' in content
+
+
+def test_create_xdebug_ini_creates_file(tmp_path):
+    ini = create_xdebug_ini(tmp_path, "8.4")
+    assert ini.exists()
+    assert ini.parent.name == "8.4d"
+
+
+def test_create_xdebug_ini_does_not_overwrite(tmp_path):
+    ini = create_xdebug_ini(tmp_path, "8.4")
+    ini.write_text("custom")
+    create_xdebug_ini(tmp_path, "8.4")
+    assert ini.read_text() == "custom"
+
+
+def test_debug_scan_dir_format():
+    result = debug_scan_dir(PREFIX, "8.4")
+    assert result == "/opt/pbrew/etc/conf.d/8.4:/opt/pbrew/etc/conf.d/8.4d"


### PR DESCRIPTION
Task 3 aus Plan 2. Kein `-n` zum Deaktivieren aller Extensions – stattdessen zweiter scan-dir (`conf.d/8.4d/`) mit xdebug.ini, und `php84d` setzt PHP_INI_SCAN_DIR auf beide. 7 Tests grün. Closes #45