### PR TITLE
Plan 3 Task 2: Extension-Installer + INI-Management

### DIFF
--- a/pbrew/extensions/installer.py
+++ b/pbrew/extensions/installer.py
@@ -1,0 +1,68 @@
+import subprocess
+import tarfile
+from pathlib import Path
+from typing import IO
+
+
+def extract_tarball(tarball: Path, dest_dir: Path) -> Path:
+    """Entpackt Tarball nach dest_dir, gibt das Source-Verzeichnis zurück."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(tarball) as tar:
+        top_level = tar.getnames()[0].split("/")[0]
+        tar.extractall(dest_dir, filter="data")
+    return dest_dir / top_level
+
+
+def install_extension(
+    prefix: Path,
+    version: str,
+    ext_name: str,
+    src_dir: Path,
+    jobs: int,
+    log_file: IO[str],
+) -> None:
+    """Baut eine PHP-Extension via phpize → configure → make → make install."""
+    phpize = prefix / "versions" / version / "bin" / "phpize"
+    php_config = prefix / "versions" / version / "bin" / "php-config"
+
+    _run([str(phpize)], cwd=src_dir, log_file=log_file)
+    _run(
+        [str(src_dir / "configure"), f"--with-php-config={php_config}"],
+        cwd=src_dir,
+        log_file=log_file,
+    )
+    _run(["make", f"-j{jobs}"], cwd=src_dir, log_file=log_file)
+    _run(["make", "install"], cwd=src_dir, log_file=log_file)
+
+
+def write_ext_ini(
+    prefix: Path,
+    family: str,
+    ext_name: str,
+    is_zend: bool = False,
+) -> Path:
+    """Schreibt Extension-INI in den shared scan-dir. Bestehende nie überschreiben."""
+    ini_dir = prefix / "etc" / "conf.d" / family
+    ini_dir.mkdir(parents=True, exist_ok=True)
+    ini = ini_dir / f"{ext_name}.ini"
+    if ini.exists():
+        return ini
+    directive = "zend_extension" if is_zend else "extension"
+    ini.write_text(f"{directive}={ext_name}.so\n")
+    return ini
+
+
+def _run(cmd: list[str], cwd: Path, log_file: IO[str]) -> None:
+    process = subprocess.Popen(
+        cmd,
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    for line in process.stdout:
+        log_file.write(line)
+        log_file.flush()
+    process.wait()
+    if process.returncode != 0:
+        raise subprocess.CalledProcessError(process.returncode, cmd)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,0 +1,83 @@
+import tarfile
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from pbrew.extensions.installer import (
+    extract_tarball,
+    install_extension,
+    write_ext_ini,
+)
+
+PREFIX = Path("/opt/pbrew")
+
+
+def _make_tgz(tmp_path: Path, name: str) -> Path:
+    """Erstellt einen minimalen .tgz für Tests."""
+    src = tmp_path / name
+    src.mkdir()
+    (src / "config.m4").write_text("PHP_ARG_ENABLE(myext)")
+    tgz = tmp_path / f"{name}.tgz"
+    with tarfile.open(tgz, "w:gz") as tar:
+        tar.add(src, arcname=name)
+    return tgz
+
+
+def test_extract_tarball_returns_src_dir(tmp_path):
+    tgz = _make_tgz(tmp_path, "xdebug-3.3.2")
+    dest = tmp_path / "build"
+    src_dir = extract_tarball(tgz, dest)
+    assert src_dir.exists()
+    assert src_dir.name == "xdebug-3.3.2"
+
+
+def test_extract_tarball_creates_dest_dir(tmp_path):
+    tgz = _make_tgz(tmp_path, "apcu-5.1.0")
+    dest = tmp_path / "build" / "nested"
+    extract_tarball(tgz, dest)
+    assert dest.exists()
+
+
+def test_write_ext_ini_creates_file(tmp_path):
+    ini = write_ext_ini(tmp_path, "8.4", "apcu")
+    assert ini.exists()
+    assert ini.read_text() == "extension=apcu.so\n"
+
+
+def test_write_ext_ini_zend_extension(tmp_path):
+    ini = write_ext_ini(tmp_path, "8.4", "xdebug", is_zend=True)
+    assert ini.read_text() == "zend_extension=xdebug.so\n"
+
+
+def test_write_ext_ini_does_not_overwrite(tmp_path):
+    ini = write_ext_ini(tmp_path, "8.4", "apcu")
+    ini.write_text("custom=value\n")
+    write_ext_ini(tmp_path, "8.4", "apcu")
+    assert ini.read_text() == "custom=value\n"
+
+
+def test_write_ext_ini_path(tmp_path):
+    ini = write_ext_ini(tmp_path, "8.4", "redis")
+    assert ini == tmp_path / "etc" / "conf.d" / "8.4" / "redis.ini"
+
+
+def test_install_extension_calls_phpize(tmp_path):
+    src_dir = tmp_path / "ext-src"
+    src_dir.mkdir()
+    (src_dir / "configure").write_text("#!/bin/bash\necho ok")
+    (src_dir / "configure").chmod(0o755)
+
+    calls: list[str] = []
+
+    def fake_popen(cmd, **kwargs):
+        calls.append(cmd[0].split("/")[-1] if "/" in cmd[0] else cmd[0])
+        proc = MagicMock()
+        proc.stdout = iter([])
+        proc.wait.return_value = None
+        proc.returncode = 0
+        return proc
+
+    with patch("pbrew.extensions.installer.subprocess.Popen", side_effect=fake_popen):
+        install_extension(PREFIX, "8.4.22", "myext", src_dir, 4, StringIO())
+
+    assert "phpize" in calls
+    assert "make" in calls


### PR DESCRIPTION
Baut Extensions via phpize → configure → make → make install. write_ext_ini() für etc/conf.d/{family}/. 7 Tests grün. Closes #51