### PR TITLE
Plan 3 Task 3: pbrew ext CLI (install/remove/enable/disable/list)

### DIFF
--- a/pbrew/cli/__init__.py
+++ b/pbrew/cli/__init__.py
@@ -14,6 +14,7 @@ from pbrew.cli.info import info_cmd
 from pbrew.cli.env import env_cmd
 from pbrew.cli.outdated import outdated_cmd
 from pbrew.cli.fpm import fpm_cmd
+from pbrew.cli.ext import ext_cmd
 
 
 @click.group()
@@ -43,3 +44,4 @@ main.add_command(info_cmd, name="info")
 main.add_command(env_cmd, name="env")
 main.add_command(outdated_cmd, name="outdated")
 main.add_command(fpm_cmd, name="fpm")
+main.add_command(ext_cmd, name="ext")

--- a/pbrew/cli/ext.py
+++ b/pbrew/cli/ext.py
@@ -1,0 +1,189 @@
+from pathlib import Path
+
+import click
+
+from pbrew.core.paths import (
+    family_from_version, logs_dir, state_file,
+)
+from pbrew.core.state import add_extension, get_family_state
+from pbrew.extensions.installer import extract_tarball, install_extension, write_ext_ini
+from pbrew.extensions.pecl import fetch_latest_stable, fetch_releases
+from pbrew.utils.download import download
+
+# Bekannte Zend-Extensions (brauchen zend_extension= statt extension=)
+_ZEND_EXTENSIONS = {"xdebug", "opcache", "ioncube_loader"}
+
+
+@click.group("ext")
+def ext_cmd():
+    """PHP-Extensions verwalten."""
+
+
+@ext_cmd.command("install")
+@click.argument("ext_name")
+@click.argument("version_spec", required=False)
+@click.option("-v", "--version", "ext_version", default=None, help="Exakte Extension-Version")
+@click.option("-j", "--jobs", type=int, default=None)
+@click.pass_context
+def install_ext_cmd(ctx, ext_name, version_spec, ext_version, jobs):
+    """Installiert eine PECL-Extension für die aktive (oder angegebene) PHP-Version."""
+    prefix: Path = ctx.obj["prefix"]
+    family = _resolve_family(prefix, version_spec)
+    php_version = _resolve_active_version(prefix, family)
+
+    click.echo(f"Installiere {ext_name} für PHP {php_version}...")
+
+    if ext_version:
+        releases = fetch_releases(ext_name)
+        release = next((r for r in releases if r.version == ext_version), None)
+        if not release:
+            click.echo(f"Version {ext_version} nicht gefunden.", err=True)
+            raise SystemExit(1)
+    else:
+        click.echo(f"  Suche neueste stabile Version von {ext_name}...")
+        release = fetch_latest_stable(ext_name)
+        click.echo(f"  Neueste stabile Version: {release.version}")
+
+    dist_dir = prefix / "distfiles"
+    dist_dir.mkdir(parents=True, exist_ok=True)
+    tarball = dist_dir / f"{ext_name}-{release.version}.tgz"
+    if not tarball.exists():
+        click.echo(f"  Lade {ext_name}-{release.version}.tgz herunter...")
+        download(release.tarball_url, tarball)
+
+    build_dir = prefix / "build" / f"{ext_name}-{release.version}"
+    if not build_dir.exists():
+        src_dir = extract_tarball(tarball, build_dir.parent)
+        if src_dir != build_dir:
+            src_dir.rename(build_dir)
+
+    from pbrew.core.builder import get_jobs
+    from pbrew.core.config import load_config
+    from pbrew.core.paths import configs_dir
+    config = load_config(configs_dir(prefix), family)
+    num_jobs = get_jobs(config, override=jobs)
+
+    log_path = logs_dir(prefix) / f"{ext_name}-{release.version}-{php_version}.log"
+    logs_dir(prefix).mkdir(parents=True, exist_ok=True)
+
+    click.echo(f"  Baue {ext_name} {release.version}...")
+    with open(log_path, "w") as log:
+        try:
+            install_extension(prefix, php_version, ext_name, build_dir, num_jobs, log)
+        except Exception as exc:
+            click.echo(f"  Fehler beim Build. Log: {log_path}", err=True)
+            click.echo(f"  {exc}", err=True)
+            raise SystemExit(1)
+
+    is_zend = ext_name.lower() in _ZEND_EXTENSIONS
+    ini = write_ext_ini(prefix, family, ext_name, is_zend=is_zend)
+    click.echo(f"  INI: {ini}")
+
+    sf = state_file(prefix, family)
+    add_extension(sf, ext_name)
+    click.echo(f"✓ {ext_name} {release.version} installiert.")
+
+
+@ext_cmd.command("remove")
+@click.argument("ext_name")
+@click.argument("version_spec", required=False)
+@click.pass_context
+def remove_ext_cmd(ctx, ext_name, version_spec):
+    """Deaktiviert eine Extension (verschiebt INI zu .disabled)."""
+    prefix: Path = ctx.obj["prefix"]
+    family = _resolve_family(prefix, version_spec)
+    ini = prefix / "etc" / "conf.d" / family / f"{ext_name}.ini"
+    if not ini.exists():
+        click.echo(f"{ext_name}.ini nicht gefunden für PHP {family}.", err=True)
+        raise SystemExit(1)
+    disabled = ini.with_suffix(".ini.disabled")
+    ini.rename(disabled)
+    click.echo(f"✓ {ext_name} deaktiviert (INI: {disabled})")
+
+
+@ext_cmd.command("enable")
+@click.argument("ext_name")
+@click.argument("version_spec", required=False)
+@click.pass_context
+def enable_ext_cmd(ctx, ext_name, version_spec):
+    """Aktiviert eine deaktivierte Extension."""
+    prefix: Path = ctx.obj["prefix"]
+    family = _resolve_family(prefix, version_spec)
+    confd = prefix / "etc" / "conf.d" / family
+    disabled = confd / f"{ext_name}.ini.disabled"
+    ini = confd / f"{ext_name}.ini"
+    if not disabled.exists():
+        if ini.exists():
+            click.echo(f"{ext_name} ist bereits aktiv.")
+        else:
+            click.echo(f"{ext_name}.ini.disabled nicht gefunden.", err=True)
+            raise SystemExit(1)
+        return
+    disabled.rename(ini)
+    click.echo(f"✓ {ext_name} aktiviert.")
+
+
+@ext_cmd.command("disable")
+@click.argument("ext_name")
+@click.argument("version_spec", required=False)
+@click.pass_context
+def disable_ext_cmd(ctx, ext_name, version_spec):
+    """Deaktiviert eine Extension (Alias für remove ohne State-Änderung)."""
+    prefix: Path = ctx.obj["prefix"]
+    family = _resolve_family(prefix, version_spec)
+    ini = prefix / "etc" / "conf.d" / family / f"{ext_name}.ini"
+    if not ini.exists():
+        click.echo(f"{ext_name} ist bereits deaktiviert oder nicht installiert.")
+        return
+    ini.rename(ini.with_suffix(".ini.disabled"))
+    click.echo(f"✓ {ext_name} deaktiviert.")
+
+
+@ext_cmd.command("list")
+@click.argument("version_spec", required=False)
+@click.pass_context
+def list_ext_cmd(ctx, version_spec):
+    """Listet installierte Extensions für eine PHP-Family."""
+    prefix: Path = ctx.obj["prefix"]
+    family = _resolve_family(prefix, version_spec)
+    confd = prefix / "etc" / "conf.d" / family
+    if not confd.exists():
+        click.echo(f"Kein scan-dir für PHP {family} gefunden.")
+        return
+    click.echo(f"\nExtensions für PHP {family} ({confd}):")
+    for ini in sorted(confd.glob("*.ini")):
+        click.echo(f"  [aktiv]    {ini.stem}")
+    for ini in sorted(confd.glob("*.ini.disabled")):
+        # stem gibt hier "{name}.ini" zurück – das .ini entfernen
+        name = ini.name.removesuffix(".ini.disabled")
+        click.echo(f"  [inaktiv]  {name}")
+    click.echo()
+
+
+def _resolve_family(prefix: Path, version_spec: "str | None") -> str:
+    if version_spec:
+        return family_from_version(version_spec)
+    import os
+    env = os.environ.get("PBREW_PHP")
+    if env:
+        return family_from_version(env)
+    from pbrew.core.state import get_global_state
+    from pbrew.core.paths import global_state_file
+    state = get_global_state(global_state_file(prefix))
+    family = state.get("default_family")
+    if not family:
+        raise click.UsageError(
+            "Keine aktive PHP-Version. Angeben: pbrew ext install apcu 84"
+        )
+    return family
+
+
+def _resolve_active_version(prefix: Path, family: str) -> str:
+    sf = state_file(prefix, family)
+    state = get_family_state(sf)
+    version = state.get("active")
+    if not version:
+        raise click.UsageError(
+            f"PHP {family} ist nicht installiert. Zuerst: pbrew install {family}"
+        )
+    return version

--- a/tests/test_ext_cli.py
+++ b/tests/test_ext_cli.py
@@ -1,0 +1,141 @@
+import json
+import os
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+
+
+def _setup_version(prefix, family="8.4", version="8.4.22"):
+    (prefix / "versions" / version / "bin").mkdir(parents=True)
+    state_dir = prefix / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir / f"{family}.json").write_text(json.dumps({"active": version}))
+    (state_dir / "global.json").write_text(json.dumps({"default_family": family}))
+
+
+def _write_ini(prefix, family, ext_name, disabled=False):
+    confd = prefix / "etc" / "conf.d" / family
+    confd.mkdir(parents=True, exist_ok=True)
+    suffix = ".ini.disabled" if disabled else ".ini"
+    path = confd / f"{ext_name}{suffix}"
+    path.write_text(f"extension={ext_name}.so\n")
+    return path
+
+
+def _invoke(prefix, tmp_path, *args, env_extra=None):
+    runner = CliRunner()
+    env = {"XDG_CONFIG_HOME": str(tmp_path / "config")}
+    if env_extra:
+        env.update(env_extra)
+    with patch.dict(os.environ, env):
+        return runner.invoke(main, ["--prefix", str(prefix)] + list(args))
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+def test_ext_list_shows_active_and_inactive(tmp_path):
+    _setup_version(tmp_path)
+    _write_ini(tmp_path, "8.4", "apcu")
+    _write_ini(tmp_path, "8.4", "xdebug", disabled=True)
+    result = _invoke(tmp_path, tmp_path, "ext", "list", "8.4")
+    assert result.exit_code == 0, result.output
+    assert "apcu" in result.output
+    assert "xdebug" in result.output
+    assert "aktiv" in result.output
+    assert "inaktiv" in result.output
+
+
+def test_ext_list_without_scan_dir(tmp_path):
+    _setup_version(tmp_path)
+    result = _invoke(tmp_path, tmp_path, "ext", "list", "8.4")
+    assert result.exit_code == 0
+    assert "Kein scan-dir" in result.output
+
+
+# ---------------------------------------------------------------------------
+# disable / enable
+# ---------------------------------------------------------------------------
+
+def test_ext_disable_renames_ini(tmp_path):
+    _setup_version(tmp_path)
+    _write_ini(tmp_path, "8.4", "apcu")
+    result = _invoke(tmp_path, tmp_path, "ext", "disable", "apcu", "8.4")
+    assert result.exit_code == 0, result.output
+    assert not (tmp_path / "etc" / "conf.d" / "8.4" / "apcu.ini").exists()
+    assert (tmp_path / "etc" / "conf.d" / "8.4" / "apcu.ini.disabled").exists()
+
+
+def test_ext_enable_renames_back(tmp_path):
+    _setup_version(tmp_path)
+    _write_ini(tmp_path, "8.4", "apcu", disabled=True)
+    result = _invoke(tmp_path, tmp_path, "ext", "enable", "apcu", "8.4")
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "etc" / "conf.d" / "8.4" / "apcu.ini").exists()
+    assert not (tmp_path / "etc" / "conf.d" / "8.4" / "apcu.ini.disabled").exists()
+
+
+def test_ext_enable_already_active(tmp_path):
+    _setup_version(tmp_path)
+    _write_ini(tmp_path, "8.4", "apcu")
+    result = _invoke(tmp_path, tmp_path, "ext", "enable", "apcu", "8.4")
+    assert result.exit_code == 0
+    assert "bereits aktiv" in result.output
+
+
+def test_ext_disable_already_disabled(tmp_path):
+    _setup_version(tmp_path)
+    result = _invoke(tmp_path, tmp_path, "ext", "disable", "ghost", "8.4")
+    assert result.exit_code == 0
+    assert "bereits deaktiviert" in result.output
+
+
+# ---------------------------------------------------------------------------
+# remove
+# ---------------------------------------------------------------------------
+
+def test_ext_remove_existing(tmp_path):
+    _setup_version(tmp_path)
+    _write_ini(tmp_path, "8.4", "apcu")
+    result = _invoke(tmp_path, tmp_path, "ext", "remove", "apcu", "8.4")
+    assert result.exit_code == 0
+    assert (tmp_path / "etc" / "conf.d" / "8.4" / "apcu.ini.disabled").exists()
+
+
+def test_ext_remove_missing_fails(tmp_path):
+    _setup_version(tmp_path)
+    result = _invoke(tmp_path, tmp_path, "ext", "remove", "ghost", "8.4")
+    assert result.exit_code != 0
+    assert "nicht gefunden" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Family-Resolver
+# ---------------------------------------------------------------------------
+
+def test_family_resolved_from_env(tmp_path):
+    """Ohne explizites Argument wird PBREW_PHP verwendet."""
+    _setup_version(tmp_path)
+    _write_ini(tmp_path, "8.4", "apcu")
+    result = _invoke(tmp_path, tmp_path, "ext", "list", env_extra={"PBREW_PHP": "8.4"})
+    assert result.exit_code == 0
+    assert "apcu" in result.output
+
+
+def test_family_resolved_from_global_state(tmp_path):
+    """Ohne PBREW_PHP fällt er auf global state's default_family zurück."""
+    _setup_version(tmp_path)
+    _write_ini(tmp_path, "8.4", "apcu")
+    # Kein PBREW_PHP; global state hat default_family=8.4
+    result = _invoke(tmp_path, tmp_path, "ext", "list")
+    assert result.exit_code == 0, result.output
+    assert "apcu" in result.output
+
+
+def test_family_error_without_any_hint(tmp_path):
+    """Keine Argumente, kein Env, kein Global → Fehler mit Hinweis."""
+    # Kein setup – also auch kein global.json mit default_family
+    result = _invoke(tmp_path, tmp_path, "ext", "list")
+    assert result.exit_code != 0
+    assert "Keine aktive PHP-Version" in result.output


### PR DESCRIPTION
Click-Gruppe `pbrew ext` mit install (PECL → phpize → build → INI), remove/disable (auf .ini.disabled), enable, list (aktiv+inaktiv getrennt). Family-Resolver: Arg > PBREW_PHP > global default. Zend-Extensions automatisch erkannt. 11 Tests grün. Closes #53