### PR TITLE
Plan 3 Task 5: pbrew config (edit/show) — schließt Plan 3 ab

### DIFF
--- a/pbrew/cli/__init__.py
+++ b/pbrew/cli/__init__.py
@@ -16,6 +16,7 @@ from pbrew.cli.outdated import outdated_cmd
 from pbrew.cli.fpm import fpm_cmd
 from pbrew.cli.ext import ext_cmd
 from pbrew.cli.upgrade import upgrade_cmd, rollback_cmd
+from pbrew.cli.config_ import config_cmd
 
 
 @click.group()
@@ -48,3 +49,4 @@ main.add_command(fpm_cmd, name="fpm")
 main.add_command(ext_cmd, name="ext")
 main.add_command(upgrade_cmd, name="upgrade")
 main.add_command(rollback_cmd, name="rollback")
+main.add_command(config_cmd, name="config")

--- a/pbrew/cli/config_.py
+++ b/pbrew/cli/config_.py
@@ -1,0 +1,53 @@
+import os
+import subprocess
+from pathlib import Path
+
+import click
+import tomlkit
+
+from pbrew.core.config import load_config
+from pbrew.core.paths import configs_dir, family_from_version
+
+
+@click.group("config")
+def config_cmd():
+    """Build-Config verwalten."""
+
+
+@config_cmd.command("edit")
+@click.argument("version_spec")
+@click.option("--named", default=None, help="Benannte Config (z.B. production)")
+@click.pass_context
+def edit_cmd(ctx, version_spec, named):
+    """Öffnet die Config im $EDITOR (Default: nano)."""
+    prefix: Path = ctx.obj["prefix"]
+    family = family_from_version(version_spec)
+    name = named or family
+    cfgs_dir = configs_dir(prefix)
+    cfgs_dir.mkdir(parents=True, exist_ok=True)
+    config_file = cfgs_dir / f"{name}.toml"
+
+    if not config_file.exists():
+        # Aktuell geladene (ge-merg-te) Config als Startvorlage schreiben
+        current = load_config(cfgs_dir, family, named=named)
+        config_file.write_text(tomlkit.dumps(current))
+        click.echo(f"  Vorlage erstellt: {config_file}")
+
+    editor = os.environ.get("EDITOR", "nano")
+    subprocess.run([editor, str(config_file)])
+
+
+@config_cmd.command("show")
+@click.argument("version_spec")
+@click.option("--named", default=None, help="Benannte Config")
+@click.pass_context
+def show_cmd(ctx, version_spec, named):
+    """Zeigt die aktive Config (nach Cascade-Auflösung)."""
+    prefix: Path = ctx.obj["prefix"]
+    family = family_from_version(version_spec)
+    cfgs_dir = configs_dir(prefix)
+    config = load_config(cfgs_dir, family, named=named)
+
+    click.echo(f"\n# Aktive Config für PHP {family}" +
+               (f" (Variante: {named})" if named else ""))
+    click.echo(tomlkit.dumps(config))

--- a/tests/test_config_cmd.py
+++ b/tests/test_config_cmd.py
@@ -1,0 +1,67 @@
+import os
+import tomlkit
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+
+
+def _invoke(prefix, tmp_path, *args):
+    runner = CliRunner()
+    env = {"XDG_CONFIG_HOME": str(tmp_path / "config"), "EDITOR": "true"}
+    with patch.dict(os.environ, env):
+        return runner.invoke(main, ["--prefix", str(prefix)] + list(args))
+
+
+# ---------------------------------------------------------------------------
+# config show
+# ---------------------------------------------------------------------------
+
+def test_config_show_prints_default_cascade(tmp_path):
+    result = _invoke(tmp_path, tmp_path, "config", "show", "8.4")
+    assert result.exit_code == 0, result.output
+    assert "build" in result.output
+    assert "variants" in result.output
+
+
+def test_config_show_with_named_variant(tmp_path):
+    cfgs = tmp_path / "configs"
+    cfgs.mkdir(parents=True)
+    (cfgs / "production.toml").write_text(
+        tomlkit.dumps({"build": {"jobs": 4}})
+    )
+    result = _invoke(tmp_path, tmp_path, "config", "show", "8.4", "--named", "production")
+    assert result.exit_code == 0, result.output
+    assert "production" in result.output or "4" in result.output
+
+
+# ---------------------------------------------------------------------------
+# config edit
+# ---------------------------------------------------------------------------
+
+def test_config_edit_creates_template_when_missing(tmp_path):
+    # EDITOR=true beendet sofort, ändert nichts
+    result = _invoke(tmp_path, tmp_path, "config", "edit", "8.4")
+    assert result.exit_code == 0, result.output
+    config_file = tmp_path / "configs" / "8.4.toml"
+    assert config_file.exists()
+    # Template enthält Basis-Struktur
+    data = tomlkit.loads(config_file.read_text())
+    assert "build" in data
+
+
+def test_config_edit_respects_named(tmp_path):
+    result = _invoke(tmp_path, tmp_path, "config", "edit", "8.4", "--named", "prod")
+    assert result.exit_code == 0, result.output
+    config_file = tmp_path / "configs" / "prod.toml"
+    assert config_file.exists()
+
+
+def test_config_edit_does_not_overwrite_existing(tmp_path):
+    cfgs = tmp_path / "configs"
+    cfgs.mkdir(parents=True)
+    config_file = cfgs / "8.4.toml"
+    config_file.write_text('custom = "value"\n')
+    result = _invoke(tmp_path, tmp_path, "config", "edit", "8.4")
+    assert result.exit_code == 0, result.output
+    # Custom-Inhalt bleibt erhalten (EDITOR=true schreibt nicht)
+    assert 'custom = "value"' in config_file.read_text()


### PR DESCRIPTION
config show druckt aufgelöste Cascade-Config, config edit öffnet im $EDITOR (schreibt Vorlage aus aktueller Config wenn Datei fehlt, überschreibt nie). 5 Tests grün. Closes #57