### PR TITLE
Statischer Bash-Wrapper statt eval in .bashrc

### DIFF
--- a/pbrew/cli/init_.py
+++ b/pbrew/cli/init_.py
@@ -15,12 +15,13 @@ from pbrew.core.paths import (
 )
 from pbrew.core.prerequisites import check_prerequisites, install_hint
 from pbrew.core.shell import (
-    SHELL_MAP,
     _rc_file_for,
     already_integrated,
     append_shell_integration,
     detect_shell,
+    path_export_snippet,
 )
+from pbrew.core.wrapper_script import write_wrapper_script
 
 
 @click.command("init")
@@ -44,6 +45,10 @@ def init_cmd():
         d.mkdir(parents=True, exist_ok=True)
         click.echo(f"  ✓ {d.relative_to(prefix)}/")
 
+    # Wrapper-Skript schreiben
+    wrapper = write_wrapper_script(prefix)
+    click.echo(f"\n  ✓ Wrapper-Skript: {wrapper}")
+
     created = init_profiles(configs_dir(prefix))
     if created:
         click.echo(f"\nBuild-Profile angelegt: {', '.join(created)}")
@@ -54,7 +59,7 @@ def init_cmd():
     write_prefix(prefix)
     click.echo(f"\nKonfiguration gespeichert: {global_config_file()}")
 
-    _setup_shell_integration()
+    _setup_shell_integration(prefix)
     _check_build_prerequisites()
 
     click.echo("\npbrew ist eingerichtet. Weiter mit:")
@@ -79,31 +84,23 @@ def _check_build_prerequisites() -> None:
         click.echo("  Alle Build-Tools vorhanden.")
 
 
-def _setup_shell_integration() -> None:
+def _setup_shell_integration(prefix: Path) -> None:
     click.echo("\nShell-Integration:")
     shell = detect_shell()
     if shell is None:
         click.echo("  Shell nicht erkannt – bitte manuell einrichten.")
-        _print_manual_hint(None)
+        click.echo(f'  export PATH="{bin_dir(prefix)}:$PATH"')
         return
 
     rc_file = _rc_file_for(shell)
-    snippet = SHELL_MAP[shell]["snippet"]
+    snippet = path_export_snippet(prefix, shell)
 
     if already_integrated(rc_file):
         click.echo(f"  ✓ Bereits in {rc_file} eingetragen.")
         return
 
-    if click.confirm(f"  Integration in {rc_file} eintragen?", default=True):
+    if click.confirm(f"  PATH-Eintrag in {rc_file} eintragen?", default=True):
         append_shell_integration(rc_file, snippet)
         click.echo(f"  ✓ Eingetragen. Shell neu starten oder: source {rc_file}")
     else:
-        _print_manual_hint(shell)
-
-
-def _print_manual_hint(shell: "str | None") -> None:
-    if shell and shell in SHELL_MAP:
-        snippet = SHELL_MAP[shell]["snippet"]
-        click.echo(f"  Manuell in die RC-Datei eintragen:\n    {snippet}")
-    else:
-        click.echo("  Manuell in die RC-Datei eintragen: eval \"$(pbrew shell-init bash|zsh)\"")
+        click.echo(f"  Manuell eintragen:\n    {snippet}")

--- a/pbrew/core/shell.py
+++ b/pbrew/core/shell.py
@@ -1,22 +1,24 @@
 import os
 from pathlib import Path
 
-_MARKER = "pbrew shell-init"
+# Marker-Strings zur Erkennung bestehender Integration (alt + neu).
+# Wird von already_integrated() geprüft.
+_MARKERS = ("pbrew shell-init", "pbrew/bin")
+
 
 SHELL_MAP: dict[str, dict] = {
-    "bash": {
-        "snippet": 'eval "$(pbrew shell-init bash)"',
-        "rc": "~/.bashrc",
-    },
-    "zsh": {
-        "snippet": 'eval "$(pbrew shell-init zsh)"',
-        "rc": "~/.zshrc",
-    },
-    "fish": {
-        "snippet": "pbrew shell-init fish | source",
-        "rc": "~/.config/fish/config.fish",
-    },
+    "bash": {"rc": "~/.bashrc"},
+    "zsh":  {"rc": "~/.zshrc"},
+    "fish": {"rc": "~/.config/fish/config.fish"},
 }
+
+
+def path_export_snippet(prefix: Path, shell: str) -> str:
+    """Gibt das Shell-Snippet für die PATH-Erweiterung zurück."""
+    bdir = prefix / "bin"
+    if shell == "fish":
+        return f"fish_add_path {bdir}"
+    return f'export PATH="{bdir}:$PATH"'
 
 
 def detect_shell() -> "str | None":
@@ -32,10 +34,11 @@ def _rc_file_for(shell: str) -> Path:
 
 
 def already_integrated(rc_file: Path) -> bool:
-    """Prüft, ob pbrew bereits in der RC-Datei eingetragen ist."""
+    """Prüft, ob pbrew bereits in der RC-Datei eingetragen ist (alt oder neu)."""
     if not rc_file.exists():
         return False
-    return _MARKER in rc_file.read_text()
+    text = rc_file.read_text()
+    return any(marker in text for marker in _MARKERS)
 
 
 def append_shell_integration(rc_file: Path, snippet: str) -> None:

--- a/pbrew/core/wrapper_script.py
+++ b/pbrew/core/wrapper_script.py
@@ -1,0 +1,68 @@
+"""Generiert das statische Bash-Wrapper-Skript für ~/.pbrew/bin/pbrew.
+
+Das Skript findet das Python-pbrew automatisch:
+1. Dediziertes venv unter $PBREW_ROOT/.venv/
+2. Global installiertes pbrew im PATH
+3. Auto-Setup: venv anlegen + pip install
+
+Kein `activate`, kein VIRTUAL_ENV, kein PATH-Manipulation.
+Binaries werden immer über absolute Pfade aufgerufen.
+"""
+from pathlib import Path
+
+
+def generate_wrapper_script(prefix: Path) -> str:
+    """Gibt den Inhalt des Bash-Wrapper-Skripts zurück mit eingebackenem Prefix."""
+    return f'''\
+#!/bin/bash
+# pbrew — PHP Version Manager (Wrapper)
+# Generiert von 'pbrew init'. Findet das Python-pbrew automatisch.
+# Kein activate, kein VIRTUAL_ENV — Aufruf über absolute Pfade.
+
+PBREW_ROOT="${{PBREW_ROOT:-{prefix}}}"
+
+# ── Prüfkette: wo ist das echte Python-pbrew? ─────────────────
+if [[ -x "$PBREW_ROOT/.venv/bin/pbrew" ]]; then
+    # 1. Dediziertes venv (häufigster Fall)
+    _pbrew="$PBREW_ROOT/.venv/bin/pbrew"
+
+elif _global=$(PATH="${{PATH//$PBREW_ROOT\\/bin:/}}" command -v pbrew 2>/dev/null); then
+    # 2. Global installiert (pip install pbrew system-weit oder --user)
+    _pbrew="$_global"
+
+else
+    # 3. Ersteinrichtung: venv anlegen
+    echo "pbrew: Richte Python-Umgebung ein..." >&2
+    python3 -m venv "$PBREW_ROOT/.venv" || {{ echo "pbrew: python3 -m venv fehlgeschlagen" >&2; exit 1; }}
+    "$PBREW_ROOT/.venv/bin/pip" install -q pbrew || {{ echo "pbrew: pip install pbrew fehlgeschlagen" >&2; exit 1; }}
+    _pbrew="$PBREW_ROOT/.venv/bin/pbrew"
+fi
+
+# use/switch müssen Env-Variablen in der aktuellen Shell setzen.
+# Das ist der einzige Punkt, an dem die Ausgabe des Python-Prozesses
+# als Shell-Code interpretiert wird — unvermeidbar, weil ein
+# Child-Prozess die Env des Parents nicht direkt ändern kann.
+case "$1" in
+    use|switch)
+        _output="$("$_pbrew" "$@")"
+        _rc=$?
+        [[ $_rc -eq 0 ]] && builtin eval "$_output"
+        exit $_rc
+        ;;
+    *)
+        exec "$_pbrew" "$@"
+        ;;
+esac
+'''
+
+
+def write_wrapper_script(prefix: Path, overwrite: bool = True) -> Path:
+    """Schreibt das Wrapper-Skript nach {prefix}/bin/pbrew."""
+    bdir = prefix / "bin"
+    bdir.mkdir(parents=True, exist_ok=True)
+    wrapper = bdir / "pbrew"
+    if wrapper.exists() and not overwrite:
+        return wrapper
+    wrapper.write_text(generate_wrapper_script(prefix))
+    wrapper.chmod(0o755)
+    return wrapper

--- a/tests/test_shell_integration.py
+++ b/tests/test_shell_integration.py
@@ -111,7 +111,9 @@ def test_init_integrates_shell_when_confirmed(tmp_path):
         result = runner.invoke(main, ["init"], input=f"{prefix}\ny\n")
     assert result.exit_code == 0, result.output
     assert rc_file.exists()
-    assert "pbrew shell-init bash" in rc_file.read_text()
+    text = rc_file.read_text()
+    assert "export PATH=" in text
+    assert "pbrew/bin" in text
 
 
 def test_init_skips_shell_when_declined(tmp_path):
@@ -139,5 +141,5 @@ def test_init_shell_idempotent(tmp_path):
     with patch.dict(os.environ, env), patch("pbrew.cli.init_._rc_file_for", return_value=rc_file):
         runner.invoke(main, ["init"], input=f"{prefix}\ny\n")
         runner.invoke(main, ["init"], input=f"{prefix}\ny\n")
-    count = rc_file.read_text().count("pbrew shell-init bash")
-    assert count == 1, f"Marker {count}× eingetragen statt einmal"
+    count = rc_file.read_text().count("pbrew/bin")
+    assert count == 1, f"PATH-Eintrag {count}× statt einmal"

--- a/tests/test_wrapper_script.py
+++ b/tests/test_wrapper_script.py
@@ -1,0 +1,143 @@
+import os
+import stat
+from pathlib import Path
+from unittest.mock import patch
+from click.testing import CliRunner
+
+from pbrew.core.wrapper_script import generate_wrapper_script, write_wrapper_script
+from pbrew.core.shell import already_integrated
+
+
+# ---------------------------------------------------------------------------
+# generate_wrapper_script
+# ---------------------------------------------------------------------------
+
+def test_wrapper_contains_venv_check():
+    content = generate_wrapper_script(Path("/home/alice/.pbrew"))
+    assert ".venv/bin/pbrew" in content
+
+
+def test_wrapper_contains_global_fallback():
+    content = generate_wrapper_script(Path("/home/alice/.pbrew"))
+    assert "command -v pbrew" in content
+
+
+def test_wrapper_contains_auto_setup():
+    content = generate_wrapper_script(Path("/home/alice/.pbrew"))
+    assert "python3 -m venv" in content
+    assert "pip install" in content
+
+
+def test_wrapper_contains_use_switch_handling():
+    """use/switch brauchen Sonderbehandlung um Parent-Env zu aendern."""
+    content = generate_wrapper_script(Path("/home/alice/.pbrew"))
+    assert "use|switch" in content
+
+
+def test_wrapper_contains_exec_for_normal_commands():
+    """Normale Commands per exec – kein unnötiger Subprozess."""
+    content = generate_wrapper_script(Path("/home/alice/.pbrew"))
+    assert "exec" in content
+
+
+def test_wrapper_bakes_in_prefix():
+    content = generate_wrapper_script(Path("/opt/custom-pbrew"))
+    assert "/opt/custom-pbrew" in content
+
+
+def test_wrapper_has_shebang():
+    content = generate_wrapper_script(Path("/home/alice/.pbrew"))
+    assert content.startswith("#!/bin/bash\n")
+
+
+# ---------------------------------------------------------------------------
+# write_wrapper_script
+# ---------------------------------------------------------------------------
+
+def test_write_creates_executable_file(tmp_path):
+    write_wrapper_script(tmp_path)
+    wrapper = tmp_path / "bin" / "pbrew"
+    assert wrapper.exists()
+    assert wrapper.stat().st_mode & stat.S_IXUSR
+
+
+def test_write_does_not_overwrite_existing(tmp_path):
+    (tmp_path / "bin").mkdir(parents=True)
+    wrapper = tmp_path / "bin" / "pbrew"
+    wrapper.write_text("#!/bin/bash\n# custom wrapper\n")
+    write_wrapper_script(tmp_path, overwrite=False)
+    assert "custom wrapper" in wrapper.read_text()
+
+
+def test_write_overwrites_when_requested(tmp_path):
+    (tmp_path / "bin").mkdir(parents=True)
+    wrapper = tmp_path / "bin" / "pbrew"
+    wrapper.write_text("#!/bin/bash\n# old\n")
+    write_wrapper_script(tmp_path, overwrite=True)
+    assert "old" not in wrapper.read_text()
+    assert ".venv/bin/pbrew" in wrapper.read_text()
+
+
+# ---------------------------------------------------------------------------
+# already_integrated – erkennt sowohl alte als auch neue Integration
+# ---------------------------------------------------------------------------
+
+def test_detects_old_shell_init_integration(tmp_path):
+    rc = tmp_path / ".bashrc"
+    rc.write_text('something pbrew shell-init bash\n')
+    assert already_integrated(rc)
+
+
+def test_detects_new_path_integration(tmp_path):
+    rc = tmp_path / ".bashrc"
+    rc.write_text('export PATH="$HOME/.pbrew/bin:$PATH"\n')
+    assert already_integrated(rc)
+
+
+def test_detects_custom_prefix_path(tmp_path):
+    rc = tmp_path / ".bashrc"
+    rc.write_text('export PATH="/opt/pbrew/bin:$PATH"\n')
+    assert already_integrated(rc)
+
+
+def test_no_detection_on_empty_file(tmp_path):
+    rc = tmp_path / ".bashrc"
+    rc.write_text("")
+    assert not already_integrated(rc)
+
+
+# ---------------------------------------------------------------------------
+# pbrew init schreibt Wrapper + PATH-Export
+# ---------------------------------------------------------------------------
+
+def test_init_creates_wrapper_script(tmp_path):
+    from pbrew.cli import main
+    prefix = tmp_path / "pbrew"
+    runner = CliRunner()
+    with patch.dict(os.environ, {
+        "SHELL": "/bin/bash",
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+    }), patch("pbrew.cli.init_._rc_file_for", return_value=tmp_path / ".bashrc"):
+        result = runner.invoke(main, ["init"], input=f"{prefix}\ny\n")
+    assert result.exit_code == 0, result.output
+    wrapper = prefix / "bin" / "pbrew"
+    assert wrapper.exists()
+    assert wrapper.stat().st_mode & stat.S_IXUSR
+
+
+def test_init_writes_path_export_not_shell_init(tmp_path):
+    from pbrew.cli import main
+    prefix = tmp_path / "pbrew"
+    rc_file = tmp_path / ".bashrc"
+    runner = CliRunner()
+    with patch.dict(os.environ, {
+        "SHELL": "/bin/bash",
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+    }), patch("pbrew.cli.init_._rc_file_for", return_value=rc_file):
+        result = runner.invoke(main, ["init"], input=f"{prefix}\ny\n")
+    assert result.exit_code == 0, result.output
+    content = rc_file.read_text()
+    assert "export PATH=" in content
+    assert str(prefix / "bin") in content
+    # Kein shell-init in der .bashrc
+    assert "shell-init" not in content


### PR DESCRIPTION
## Summary

Ersetzt `eval "$(pbrew shell-init bash)"` in der .bashrc durch einen statischen Bash-Wrapper.

### Vorher (kaputt)

```bash
# .bashrc
eval "$(pbrew shell-init bash)"  # ← pbrew nicht im PATH → Fehler
```

### Nachher

```bash
# .bashrc — nur noch ein PATH-Export
export PATH="$HOME/.pbrew/bin:$PATH"
```

### Wrapper-Skript (`~/.pbrew/bin/pbrew`)

1. Dediziertes venv → `$PBREW_ROOT/.venv/bin/pbrew` (Direktaufruf, kein activate)
2. Globales pbrew im PATH (nicht wir selbst)
3. Ersteinrichtung: venv + pip install

**Kein activate, kein VIRTUAL_ENV** → keine Kollision mit anderen venvs. Python wird erst bei tatsächlichem `pbrew`-Aufruf geladen, nicht beim Shell-Login.

### Dateien

- Neu: `pbrew/core/wrapper_script.py` (Template + Write-Funktion)
- Geändert: `pbrew/core/shell.py` (PATH-Export statt eval, Marker-Erkennung für alt+neu)
- Geändert: `pbrew/cli/init_.py` (schreibt Wrapper, nutzt PATH-Snippet)
- 16 neue Tests, bestehende Shell-Integration-Tests angepasst

**257 Tests grün.**

Closes #59