### PR TITLE
Versionierung: SemVer 0.5.0 + pbrew --version

### DIFF
--- a/pbrew/__init__.py
+++ b/pbrew/__init__.py
@@ -1,0 +1,6 @@
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("pbrew")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"

--- a/pbrew/cli/__init__.py
+++ b/pbrew/cli/__init__.py
@@ -20,6 +20,7 @@ from pbrew.cli.config_ import config_cmd
 
 
 @click.group()
+@click.version_option(package_name="pbrew")
 @click.option("--prefix", envvar="PBREW_ROOT", help="pbrew Prefix-Verzeichnis")
 @click.pass_context
 def main(ctx, prefix):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pbrew"
-version = "0.1.0"
+version = "0.5.0"
 description = "Python-based PHP version manager — phpbrew successor"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,9 +7,9 @@ from pbrew.cli import main
 
 
 def _invoke(tmp_path, user_input):
-    """Ruft `pbrew init` auf mit XDG_CONFIG_HOME in tmp_path."""
+    """Ruft `pbrew init` auf mit XDG_CONFIG_HOME in tmp_path. SHELL leer → kein Shell-Prompt."""
     runner = CliRunner()
-    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config")}):
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config"), "SHELL": ""}):
         return runner.invoke(main, ["init"], input=user_input)
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,20 @@
+from click.testing import CliRunner
+from pbrew.cli import main
+
+
+def test_version_flag():
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0
+    assert "version" in result.output.lower()
+    # Die Version selbst muss SemVer-Format haben
+    version_str = result.output.strip().split()[-1]
+    parts = version_str.split(".")
+    assert len(parts) >= 2, f"Kein SemVer-Format: {result.output}"
+    assert all(p.isdigit() for p in parts), f"Nicht-numerische Teile: {version_str}"
+
+
+def test_version_module_attribute():
+    from pbrew import __version__
+    assert __version__ != "0.0.0-dev"
+    assert "." in __version__


### PR DESCRIPTION
## Summary

- `pyproject.toml` → Version 0.5.0 (Foundation + FPM + Extensions + Upgrade)
- `pbrew/__init__.py` → `__version__` per `importlib.metadata` (Single Source of Truth)
- `pbrew --version` via Click's `version_option(package_name="pbrew")`
- 2 neue Tests (--version Flag, __version__ Attribut)

Closes #61