### PR TITLE
Wrapper: wrapper.env statt Auto-Detection/pip-install

### DIFF
--- a/pbrew/cli/init_.py
+++ b/pbrew/cli/init_.py
@@ -21,7 +21,7 @@ from pbrew.core.shell import (
     detect_shell,
     path_export_snippet,
 )
-from pbrew.core.wrapper_script import write_wrapper_script
+from pbrew.core.wrapper_script import detect_pbrew_bin, write_wrapper_env, write_wrapper_script
 
 
 @click.command("init")
@@ -45,9 +45,13 @@ def init_cmd():
         d.mkdir(parents=True, exist_ok=True)
         click.echo(f"  ✓ {d.relative_to(prefix)}/")
 
-    # Wrapper-Skript schreiben
+    # Wrapper-Skript + wrapper.env schreiben
     wrapper = write_wrapper_script(prefix)
+    pbrew_bin = detect_pbrew_bin()
+    env_file = write_wrapper_env(prefix, pbrew_bin)
     click.echo(f"\n  ✓ Wrapper-Skript: {wrapper}")
+    click.echo(f"  ✓ Python-pbrew:   {pbrew_bin}")
+    click.echo(f"    (gespeichert in {env_file})")
 
     created = init_profiles(configs_dir(prefix))
     if created:

--- a/pbrew/core/wrapper_script.py
+++ b/pbrew/core/wrapper_script.py
@@ -1,14 +1,46 @@
 """Generiert das statische Bash-Wrapper-Skript für ~/.pbrew/bin/pbrew.
 
-Das Skript findet das Python-pbrew automatisch:
-1. Dediziertes venv unter $PBREW_ROOT/.venv/
-2. Global installiertes pbrew im PATH
-3. Auto-Setup: venv anlegen + pip install
+Das Skript liest den Pfad zum echten Python-pbrew aus wrapper.env.
+Kein Raten, kein Auto-Install von PyPI. pbrew init erkennt die aktuelle
+Umgebung und schreibt den Pfad einmalig in die Datei.
 
 Kein `activate`, kein VIRTUAL_ENV, kein PATH-Manipulation.
 Binaries werden immer über absolute Pfade aufgerufen.
 """
+import shutil
+import sys
 from pathlib import Path
+
+
+def detect_pbrew_bin() -> Path:
+    """Ermittelt den Pfad zum aktuell laufenden pbrew-Binary.
+
+    Prüfkette:
+    1. In einem venv → {sys.prefix}/bin/pbrew
+    2. Global installiert → per shutil.which
+    3. Fallback → sys.executable (Python selbst)
+    """
+    if sys.prefix != sys.base_prefix:
+        candidate = Path(sys.prefix) / "bin" / "pbrew"
+        return candidate
+    found = shutil.which("pbrew")
+    if found:
+        return Path(found)
+    return Path(sys.executable)
+
+
+def write_wrapper_env(prefix: Path, pbrew_bin: Path) -> Path:
+    """Schreibt wrapper.env mit dem Pfad zum Python-pbrew.
+
+    Bash-sourceable: KEY="VALUE"-Format.
+    """
+    prefix.mkdir(parents=True, exist_ok=True)
+    env_file = prefix / "wrapper.env"
+    env_file.write_text(
+        f'# Generiert von "pbrew init" — zeigt auf das Python-pbrew\n'
+        f'PBREW_PYTHON_BIN="{pbrew_bin}"\n'
+    )
+    return env_file
 
 
 def generate_wrapper_script(prefix: Path) -> str:
@@ -16,48 +48,54 @@ def generate_wrapper_script(prefix: Path) -> str:
     return f'''\
 #!/bin/bash
 # pbrew — PHP Version Manager (Wrapper)
-# Generiert von 'pbrew init'. Findet das Python-pbrew automatisch.
+# Generiert von 'pbrew init'. Liest den Pfad zum Python-pbrew aus wrapper.env.
 # Kein activate, kein VIRTUAL_ENV — Aufruf über absolute Pfade.
 
 PBREW_ROOT="${{PBREW_ROOT:-{prefix}}}"
 
-# ── Prüfkette: wo ist das echte Python-pbrew? ─────────────────
-if [[ -x "$PBREW_ROOT/.venv/bin/pbrew" ]]; then
-    # 1. Dediziertes venv (häufigster Fall)
-    _pbrew="$PBREW_ROOT/.venv/bin/pbrew"
+# ── Konfiguration lesen ──────────────────────────────────────
+PBREW_PYTHON_BIN=""
 
-elif _global=$(PATH="${{PATH//$PBREW_ROOT\\/bin:/}}" command -v pbrew 2>/dev/null); then
-    # 2. Global installiert (pip install pbrew system-weit oder --user)
-    _pbrew="$_global"
+if [[ -f "$PBREW_ROOT/wrapper.env" ]]; then
+    source "$PBREW_ROOT/wrapper.env"
+elif [[ -f "/etc/pbrew/wrapper.env" ]]; then
+    source "/etc/pbrew/wrapper.env"
+fi
 
-else
-    # 3. Ersteinrichtung: venv anlegen
-    echo "pbrew: Richte Python-Umgebung ein..." >&2
-    python3 -m venv "$PBREW_ROOT/.venv" || {{ echo "pbrew: python3 -m venv fehlgeschlagen" >&2; exit 1; }}
-    "$PBREW_ROOT/.venv/bin/pip" install -q pbrew || {{ echo "pbrew: pip install pbrew fehlgeschlagen" >&2; exit 1; }}
-    _pbrew="$PBREW_ROOT/.venv/bin/pbrew"
+if [[ -z "$PBREW_PYTHON_BIN" ]] || [[ ! -x "$PBREW_PYTHON_BIN" ]]; then
+    echo "pbrew: Kein Python-pbrew konfiguriert." >&2
+    echo "" >&2
+    if [[ -n "$PBREW_PYTHON_BIN" ]]; then
+        echo "  Konfigurierter Pfad existiert nicht mehr:" >&2
+        echo "    $PBREW_PYTHON_BIN" >&2
+        echo "" >&2
+    fi
+    echo "  Lösung: pbrew aus der Umgebung aufrufen, in der es installiert ist:" >&2
+    echo "    source /pfad/zum/venv/bin/activate && pbrew init" >&2
+    echo "" >&2
+    echo "  Oder manuell wrapper.env anlegen:" >&2
+    echo "    echo 'PBREW_PYTHON_BIN=\\"/pfad/zum/venv/bin/pbrew\\"' > $PBREW_ROOT/wrapper.env" >&2
+    exit 1
 fi
 
 # use/switch müssen Env-Variablen in der aktuellen Shell setzen.
-# Das ist der einzige Punkt, an dem die Ausgabe des Python-Prozesses
-# als Shell-Code interpretiert wird — unvermeidbar, weil ein
-# Child-Prozess die Env des Parents nicht direkt ändern kann.
+# Unvermeidbar: Child-Prozess kann Parent-Env nicht direkt ändern.
 case "$1" in
     use|switch)
-        _output="$("$_pbrew" "$@")"
+        _output="$("$PBREW_PYTHON_BIN" "$@")"
         _rc=$?
         [[ $_rc -eq 0 ]] && builtin eval "$_output"
         exit $_rc
         ;;
     *)
-        exec "$_pbrew" "$@"
+        exec "$PBREW_PYTHON_BIN" "$@"
         ;;
 esac
 '''
 
 
 def write_wrapper_script(prefix: Path, overwrite: bool = True) -> Path:
-    """Schreibt das Wrapper-Skript nach {prefix}/bin/pbrew."""
+    """Schreibt das Wrapper-Skript nach {{prefix}}/bin/pbrew."""
     bdir = prefix / "bin"
     bdir.mkdir(parents=True, exist_ok=True)
     wrapper = bdir / "pbrew"

--- a/tests/test_wrapper_env.py
+++ b/tests/test_wrapper_env.py
@@ -1,0 +1,122 @@
+import os
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from pbrew.core.wrapper_script import (
+    detect_pbrew_bin,
+    generate_wrapper_script,
+    write_wrapper_env,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_pbrew_bin
+# ---------------------------------------------------------------------------
+
+def test_detect_in_venv():
+    """Wenn aus einem venv aufgerufen: {sys.prefix}/bin/pbrew."""
+    fake_prefix = "/home/alice/project/.venv"
+    with patch.object(sys, "prefix", fake_prefix), \
+         patch.object(sys, "base_prefix", "/usr"):
+        result = detect_pbrew_bin()
+    assert result == Path(fake_prefix) / "bin" / "pbrew"
+
+
+def test_detect_global_install():
+    """Wenn kein venv: sucht pbrew im PATH."""
+    with patch.object(sys, "prefix", "/usr"), \
+         patch.object(sys, "base_prefix", "/usr"), \
+         patch("pbrew.core.wrapper_script.shutil.which", return_value="/usr/local/bin/pbrew"):
+        result = detect_pbrew_bin()
+    assert result == Path("/usr/local/bin/pbrew")
+
+
+def test_detect_fallback_to_sys_executable():
+    """Kein venv, nicht im PATH: Fallback auf sys.executable."""
+    with patch.object(sys, "prefix", "/usr"), \
+         patch.object(sys, "base_prefix", "/usr"), \
+         patch("pbrew.core.wrapper_script.shutil.which", return_value=None), \
+         patch.object(sys, "executable", "/usr/bin/python3"):
+        result = detect_pbrew_bin()
+    assert result == Path("/usr/bin/python3")
+
+
+# ---------------------------------------------------------------------------
+# write_wrapper_env
+# ---------------------------------------------------------------------------
+
+def test_write_wrapper_env_creates_file(tmp_path):
+    write_wrapper_env(tmp_path, Path("/some/venv/bin/pbrew"))
+    env_file = tmp_path / "wrapper.env"
+    assert env_file.exists()
+    content = env_file.read_text()
+    assert "PBREW_PYTHON_BIN" in content
+    assert "/some/venv/bin/pbrew" in content
+
+
+def test_write_wrapper_env_is_sourceable(tmp_path):
+    """Die Datei muss bash-kompatibel sein (key=value, keine Leerzeichen um =)."""
+    write_wrapper_env(tmp_path, Path("/test/bin/pbrew"))
+    content = (tmp_path / "wrapper.env").read_text()
+    # Bash-sourceable: Zeilen müssen KEY="VALUE" sein
+    for line in content.splitlines():
+        if line.strip() and not line.startswith("#"):
+            assert "=" in line
+
+
+def test_write_wrapper_env_overwrites(tmp_path):
+    """Wiederholter Aufruf aktualisiert den Pfad."""
+    write_wrapper_env(tmp_path, Path("/old/bin/pbrew"))
+    write_wrapper_env(tmp_path, Path("/new/bin/pbrew"))
+    content = (tmp_path / "wrapper.env").read_text()
+    assert "/new/bin/pbrew" in content
+    assert "/old/bin/pbrew" not in content
+
+
+# ---------------------------------------------------------------------------
+# Wrapper-Skript liest wrapper.env
+# ---------------------------------------------------------------------------
+
+def test_wrapper_script_sources_wrapper_env():
+    content = generate_wrapper_script(Path("/home/alice/.pbrew"))
+    assert "wrapper.env" in content
+    assert "source" in content
+
+
+def test_wrapper_script_checks_etc_fallback():
+    content = generate_wrapper_script(Path("/home/alice/.pbrew"))
+    assert "/etc/pbrew/wrapper.env" in content
+
+
+def test_wrapper_script_no_pip_install():
+    """Kein Auto-Install mehr – stattdessen Fehlermeldung mit Hinweis."""
+    content = generate_wrapper_script(Path("/home/alice/.pbrew"))
+    assert "pip install" not in content
+
+
+def test_wrapper_script_shows_helpful_error():
+    content = generate_wrapper_script(Path("/home/alice/.pbrew"))
+    assert "pbrew init" in content  # Hinweis auf init
+
+
+# ---------------------------------------------------------------------------
+# pbrew init schreibt wrapper.env
+# ---------------------------------------------------------------------------
+
+def test_init_writes_wrapper_env(tmp_path):
+    from click.testing import CliRunner
+    from pbrew.cli import main
+    prefix = tmp_path / "pbrew"
+    runner = CliRunner()
+    with patch.dict(os.environ, {
+        "SHELL": "",
+        "XDG_CONFIG_HOME": str(tmp_path / "config"),
+    }):
+        result = runner.invoke(main, ["init"], input=f"{prefix}\n")
+    assert result.exit_code == 0, result.output
+    env_file = prefix / "wrapper.env"
+    assert env_file.exists()
+    content = env_file.read_text()
+    assert "PBREW_PYTHON_BIN" in content

--- a/tests/test_wrapper_script.py
+++ b/tests/test_wrapper_script.py
@@ -12,20 +12,21 @@ from pbrew.core.shell import already_integrated
 # generate_wrapper_script
 # ---------------------------------------------------------------------------
 
-def test_wrapper_contains_venv_check():
+def test_wrapper_sources_wrapper_env():
     content = generate_wrapper_script(Path("/home/alice/.pbrew"))
-    assert ".venv/bin/pbrew" in content
+    assert "wrapper.env" in content
+    assert "source" in content
 
 
-def test_wrapper_contains_global_fallback():
+def test_wrapper_checks_etc_fallback():
     content = generate_wrapper_script(Path("/home/alice/.pbrew"))
-    assert "command -v pbrew" in content
+    assert "/etc/pbrew/wrapper.env" in content
 
 
-def test_wrapper_contains_auto_setup():
+def test_wrapper_no_pip_install():
+    """Kein Auto-Install mehr – stattdessen Fehlermeldung."""
     content = generate_wrapper_script(Path("/home/alice/.pbrew"))
-    assert "python3 -m venv" in content
-    assert "pip install" in content
+    assert "pip install" not in content
 
 
 def test_wrapper_contains_use_switch_handling():
@@ -75,7 +76,7 @@ def test_write_overwrites_when_requested(tmp_path):
     wrapper.write_text("#!/bin/bash\n# old\n")
     write_wrapper_script(tmp_path, overwrite=True)
     assert "old" not in wrapper.read_text()
-    assert ".venv/bin/pbrew" in wrapper.read_text()
+    assert "wrapper.env" in wrapper.read_text()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Der Wrapper versuchte bei fehlendem pbrew \`pip install pbrew\` von PyPI – pbrew ist dort nicht.

## Lösung

\`pbrew init\` erkennt von wo es läuft (\`sys.prefix\` vs \`sys.base_prefix\`) und schreibt den absoluten Pfad in \`{prefix}/wrapper.env\`:

\`\`\`bash
PBREW_PYTHON_BIN="/home/patric/apache/projekte/pbrew/.venv/bin/pbrew"
\`\`\`

Der Wrapper sourced diese Datei → kein Raten, kein pip install.

Fallback: \`/etc/pbrew/wrapper.env\` für System-weite Root-Installs.

Fehlt alles → klare Fehlermeldung statt kryptischem pip-Fehler.

**270 Tests grün.** Closes #63