### PR TITLE
pbrew init: Root-Erkennung mit /opt/pbrew-Vorschlag

### DIFF
--- a/pbrew/cli/init_.py
+++ b/pbrew/cli/init_.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import click
@@ -28,6 +29,10 @@ from pbrew.core.wrapper_script import detect_pbrew_bin, write_wrapper_env, write
 def init_cmd():
     """Richtet pbrew ein: Prefix wählen, Verzeichnisse anlegen, Shell integrieren."""
     current_default = get_prefix()
+
+    if os.getuid() == 0:
+        if click.confirm("PHP systemweit einrichten?", default=True):
+            current_default = Path("/opt/pbrew")
 
     chosen = click.prompt("Installationspräfix", default=str(current_default))
     prefix = Path(chosen).expanduser().resolve()

--- a/tests/test_root_init.py
+++ b/tests/test_root_init.py
@@ -1,0 +1,53 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+
+
+def _invoke_init(tmp_path, user_input, uid=0):
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(tmp_path / "config"), "SHELL": ""}), \
+         patch("pbrew.cli.init_.os.getuid", return_value=uid):
+        return runner.invoke(main, ["init"], input=user_input)
+
+
+# ---------------------------------------------------------------------------
+# Root: systemweit → /opt/pbrew als Default
+# ---------------------------------------------------------------------------
+
+def test_root_asked_about_systemwide(tmp_path):
+    """Root bekommt die Frage 'systemweit einrichten?'."""
+    prefix = tmp_path / "opt-pbrew"
+    result = _invoke_init(tmp_path, f"y\n{prefix}\n", uid=0)
+    assert result.exit_code == 0, result.output
+    assert "systemweit" in result.output.lower()
+
+
+def test_root_systemwide_yes_shows_opt_default(tmp_path):
+    """Bei 'y' wird /opt/pbrew als Default im Prompt angezeigt."""
+    prefix = tmp_path / "opt-pbrew"
+    result = _invoke_init(tmp_path, f"y\n{prefix}\n", uid=0)
+    assert result.exit_code == 0, result.output
+    assert "/opt/pbrew" in result.output
+
+
+def test_root_systemwide_no_normal_flow(tmp_path):
+    """Bei 'n' → normaler Flow ohne /opt/pbrew-Default."""
+    prefix = tmp_path / "rootpbrew"
+    result = _invoke_init(tmp_path, f"n\n{prefix}\n", uid=0)
+    assert result.exit_code == 0, result.output
+    assert "/opt/pbrew" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# Normaler User: kein systemweit-Prompt
+# ---------------------------------------------------------------------------
+
+def test_normal_user_no_systemwide_prompt(tmp_path):
+    """Normaler User bekommt keine systemweit-Frage."""
+    prefix = tmp_path / "mypbrew"
+    result = _invoke_init(tmp_path, f"{prefix}\n", uid=1000)
+    assert result.exit_code == 0, result.output
+    assert "systemweit" not in result.output.lower()
+    assert (prefix / "bin" / "pbrew").exists()


### PR DESCRIPTION
Bei uid==0 fragt init 'PHP systemweit einrichten?' → bei ja wird /opt/pbrew als Default vorgeschlagen statt /root/.pbrew. Bei nein normaler Flow. 4 Tests. Closes #65