### PR TITLE
[#67] Exakte Patch-Version installieren (z.B. pbrew install 8.4.19)

### DIFF
--- a/pbrew/cli/install.py
+++ b/pbrew/cli/install.py
@@ -29,10 +29,17 @@ def install_cmd(ctx, version_spec, config_name, save, jobs, skip_lib_check):
     prefix: Path = ctx.obj["prefix"]
     family = family_from_version(version_spec)
 
-    click.echo(f"Prüfe verfügbare Versionen für PHP {family}...")
-    release = resolver.fetch_latest(family)
-    version = release.version
-    click.echo(f"  Neueste Version: {version}")
+    parts = version_spec.split(".")
+    if len(parts) == 3 and all(p.isdigit() for p in parts):
+        click.echo(f"Prüfe PHP {version_spec} auf php.net...")
+        release = resolver.fetch_specific(version_spec)
+        version = release.version
+        click.echo(f"  Version: {version}")
+    else:
+        click.echo(f"Prüfe verfügbare Versionen für PHP {family}...")
+        release = resolver.fetch_latest(family)
+        version = release.version
+        click.echo(f"  Neueste Version: {version}")
 
     vdir = version_dir(prefix, version)
     if vdir.exists():

--- a/pbrew/core/resolver.py
+++ b/pbrew/core/resolver.py
@@ -50,6 +50,29 @@ def fetch_latest(family: str) -> PhpRelease:
     return release
 
 
+def fetch_specific(version: str) -> PhpRelease:
+    """Gibt eine exakte PHP-Version zurück (z.B. '8.4.19').
+
+    Lädt alle Releases der betreffenden Family und sucht die angegebene Version.
+    Wirft RuntimeError, wenn die Version nicht gefunden wird (z.B. zu alt oder falsch).
+    """
+    parts = version.split(".")
+    if len(parts) != 3 or not all(p.isdigit() for p in parts):
+        raise ValueError(f"Vollständige Version erwartet (z.B. 8.4.19), bekommen: {version}")
+    family = f"{parts[0]}.{parts[1]}"
+    url = f"{PHP_RELEASES_URL}?json=1&version={family}&max=100"
+    data = _fetch_json(url)
+    if version not in data:
+        raise RuntimeError(
+            f"PHP {version} nicht auf php.net gefunden – "
+            f"Version nicht verfügbar oder falsch angegeben."
+        )
+    release = _parse_release(version, data[version])
+    if release is None:
+        raise RuntimeError(f"Keine .tar.bz2 Quelle für PHP {version} gefunden")
+    return release
+
+
 def fetch_known(major: int = 8) -> list[PhpRelease]:
     """Gibt alle bekannten Releases für eine Major-Version zurück.
 

--- a/tests/test_install_ux.py
+++ b/tests/test_install_ux.py
@@ -92,6 +92,38 @@ def test_output_shows_each_phase(tmp_path):
 # Bei Phasen-Fehler wird die betroffene Phase genannt
 # ---------------------------------------------------------------------------
 
+def test_install_pinned_version_uses_fetch_specific(tmp_path):
+    """Bei 3-stelliger Versionsangabe wird fetch_specific statt fetch_latest genutzt."""
+    version = "8.4.19"
+    prefix = tmp_path / "pbrew"
+    _prepare_prefix(prefix, version)
+    runner = CliRunner()
+    env = {"XDG_CONFIG_HOME": str(tmp_path / "config")}
+    with patch.dict(os.environ, env), \
+         patch("pbrew.cli.install.resolver.fetch_specific", return_value=_make_release(version)) as mfs, \
+         patch("pbrew.cli.install.resolver.fetch_latest") as mfl, \
+         patch("pbrew.cli.install.build_libs.check_required_libs", return_value=[]), \
+         patch("pbrew.cli.install.builder.run_configure", return_value=None), \
+         patch("pbrew.cli.install.builder.run_make", return_value=None), \
+         patch("pbrew.cli.install.builder.run_make_install",
+               side_effect=lambda *a, **kw: _simulate_make_install(prefix, version)), \
+         patch("pbrew.cli.install.run_basic_checks", return_value=[]):
+        result = runner.invoke(main, ["--prefix", str(prefix), "install", version])
+    assert result.exit_code == 0, result.output
+    mfs.assert_called_once_with(version)
+    mfl.assert_not_called()
+    assert "8.4.19" in result.output
+
+
+def test_install_family_uses_fetch_latest(tmp_path):
+    """Bei 2-stelliger Versionsangabe wird fetch_latest genutzt."""
+    prefix = tmp_path / "pbrew"
+    _prepare_prefix(prefix)
+    result, (mc, mm, mi) = _invoke_install(prefix, tmp_path)
+    assert result.exit_code == 0, result.output
+    assert "Neueste Version" in result.output
+
+
 def test_error_in_configure_reports_which_phase(tmp_path):
     prefix = tmp_path / "pbrew"
     _prepare_prefix(prefix)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import patch, MagicMock, call
-from pbrew.core.resolver import fetch_latest, fetch_known, PhpRelease
+import pytest
+from pbrew.core.resolver import fetch_latest, fetch_known, fetch_specific, PhpRelease
 
 
 MOCK_SINGLE = {
@@ -86,6 +87,31 @@ def test_fetch_known_sorted_descending():
         releases = fetch_known(8)
     versions = [r.version for r in releases]
     assert versions == sorted(versions, reverse=True)
+
+
+def test_fetch_specific_returns_exact_version():
+    family_data = {
+        "8.4.22": MOCK_SINGLE["8.4.22"],
+        "8.4.19": {
+            "source": [{"filename": "php-8.4.19.tar.bz2", "sha256": "old123", "md5": "x"}]
+        },
+    }
+    with patch("pbrew.core.resolver.urllib.request.urlopen", return_value=_mock_urlopen(family_data)):
+        release = fetch_specific("8.4.19")
+    assert release.version == "8.4.19"
+    assert release.sha256 == "old123"
+    assert "php-8.4.19.tar.bz2" in release.tarball_url
+
+
+def test_fetch_specific_raises_if_not_found():
+    with patch("pbrew.core.resolver.urllib.request.urlopen", return_value=_mock_urlopen(MOCK_SINGLE)):
+        with pytest.raises(RuntimeError, match="nicht auf php.net gefunden"):
+            fetch_specific("8.4.1")
+
+
+def test_fetch_specific_raises_on_invalid_format():
+    with pytest.raises(ValueError, match="Vollständige Version"):
+        fetch_specific("8.4")
 
 
 def test_fetch_known_numeric_sort_single_digit_patch():


### PR DESCRIPTION
## Summary

- `resolver.fetch_specific(version)` sucht eine exakte Version in der php.net Family-Release-Liste
- `pbrew install 8.4.19` (3-stellig) nutzt `fetch_specific`; `pbrew install 8.4` (2-stellig) nutzt weiterhin `fetch_latest`
- Fehlermeldung wenn Version nicht auf php.net verfügbar ist

## Test Plan

- [ ] `pbrew install 8.4` → installiert weiterhin die neueste 8.4.x
- [ ] `pbrew install 8.4.19` → installiert exakt 8.4.19
- [ ] `pbrew install 8.4.0` (nicht existent) → Fehlermeldung mit Hinweis
- [ ] 13 Unit-Tests grün

Closes #67