### PR TITLE
[#69] pbrew list: alle Versionen anzeigen; use/switch mit Patch-Version

### DIFF
--- a/pbrew/cli/list_.py
+++ b/pbrew/cli/list_.py
@@ -15,6 +15,7 @@ def list_cmd(ctx):
         click.echo("Keine PHP-Versionen installiert.")
         return
 
+    # Alle installierten Versionen pro Family sammeln
     installed_versions: dict[str, list[str]] = {}
     for entry in sorted(vdir.iterdir()):
         if not entry.is_dir():
@@ -25,25 +26,46 @@ def list_cmd(ctx):
             continue
         installed_versions.setdefault(family, []).append(entry.name)
 
+    # Versionen innerhalb jeder Family absteigend sortieren (neueste zuerst)
+    for family in installed_versions:
+        installed_versions[family].sort(
+            key=lambda v: tuple(int(x) for x in v.split(".")),
+            reverse=True,
+        )
+
     global_state = get_global_state(global_state_file(prefix))
     default_family = global_state.get("default_family", "")
 
-    click.echo(f"\n{'Family':<8} {'Aktiv':<12} {'Config':<12} {'Vorherige':<12} {'Wrapper':<10} {'Extensions'}")
-    click.echo("─" * 82)
+    click.echo(f"\n{'Family':<8} {'Version':<14} {'Config':<14} {'Wrapper':<10} {'Extensions'}")
+    click.echo("─" * 72)
 
     for family in sorted(installed_versions):
         sf = state_file(prefix, family)
         state = get_family_state(sf)
-        active = state.get("active", "—")
-        previous = state.get("previous", "—")
+        active = state.get("active", "")
         suffix = family_suffix(family)
-        config_name = state.get("installed", {}).get(active, {}).get("config_name") or "—"
         extensions = ", ".join(state.get("extensions", [])) or "—"
         default_mark = " *" if family == default_family else ""
-        click.echo(
-            f"  {family:<8} {active:<12} {config_name:<12} {previous:<12} "
-            f"php{suffix:<7} {extensions}{default_mark}"
-        )
+
+        for i, version in enumerate(installed_versions[family]):
+            marker = "▸" if version == active else " "
+            config_name = (
+                state.get("installed", {}).get(version, {}).get("config_name") or "—"
+            )
+
+            if i == 0:
+                family_col = family
+                wrapper_col = f"php{suffix}{default_mark}"
+                ext_col = extensions
+            else:
+                family_col = ""
+                wrapper_col = ""
+                ext_col = ""
+
+            click.echo(
+                f"  {family_col:<6} {marker} {version:<14} {config_name:<14} "
+                f"{wrapper_col:<10} {ext_col}"
+            )
 
     if default_family:
         click.echo(f"\n  * php{family_suffix(default_family)} ist der aktuelle Default")

--- a/pbrew/cli/use.py
+++ b/pbrew/cli/use.py
@@ -1,44 +1,87 @@
 from pathlib import Path
 import click
-from pbrew.core.paths import family_from_version, family_suffix, state_file, global_state_file
-from pbrew.core.state import get_family_state, set_global_default
-from pbrew.core.wrappers import write_naked_wrappers
+from pbrew.core.paths import family_from_version, family_suffix, state_file, global_state_file, version_dir
+from pbrew.core.state import get_family_state, set_active_version, set_global_default
+from pbrew.core.wrappers import write_naked_wrappers, write_versioned_wrappers
+
+
+def _is_pinned(version_spec: str) -> bool:
+    parts = version_spec.split(".")
+    return len(parts) == 3 and all(p.isdigit() for p in parts)
 
 
 @click.command("use")
 @click.argument("version_spec")
 @click.pass_context
 def use_cmd(ctx, version_spec):
-    """Setzt PHP-Version für die aktuelle Shell-Session (via Shell-Funktion)."""
+    """Setzt PHP-Version für die aktuelle Shell-Session (via Shell-Funktion).
+
+    Mit Family (8.4) wird die aktive Patch-Version genutzt.
+    Mit voller Version (8.4.19) wird exakt diese Version für die Session gesetzt.
+    """
     prefix: Path = ctx.obj["prefix"]
-    family = family_from_version(version_spec)
-    sf = state_file(prefix, family)
-    state = get_family_state(sf)
 
-    if not state.get("active"):
-        click.echo(f"PHP {family} ist nicht installiert. Zuerst: pbrew install {family}", err=True)
-        raise SystemExit(1)
-
-    click.echo(f"export PBREW_PHP={family}")
-    click.echo(f'export PATH="{prefix / "bin"}:$PATH"')
-    click.echo("hash -r")
+    if _is_pinned(version_spec):
+        vdir = version_dir(prefix, version_spec)
+        if not vdir.exists():
+            click.echo(
+                f"PHP {version_spec} ist nicht installiert. "
+                f"Zuerst: pbrew install {version_spec}",
+                err=True,
+            )
+            raise SystemExit(1)
+        click.echo(f'export PATH="{vdir / "bin"}:{prefix / "bin"}:$PATH"')
+        click.echo("hash -r")
+    else:
+        family = family_from_version(version_spec)
+        sf = state_file(prefix, family)
+        state = get_family_state(sf)
+        if not state.get("active"):
+            click.echo(
+                f"PHP {family} ist nicht installiert. Zuerst: pbrew install {family}",
+                err=True,
+            )
+            raise SystemExit(1)
+        click.echo(f"export PBREW_PHP={family}")
+        click.echo(f'export PATH="{prefix / "bin"}:$PATH"')
+        click.echo("hash -r")
 
 
 @click.command("switch")
 @click.argument("version_spec")
 @click.pass_context
 def switch_cmd(ctx, version_spec):
-    """Setzt PHP-Version permanent als Default und aktualisiert php/phpd-Wrapper."""
+    """Setzt PHP-Version permanent als Default und aktualisiert php/phpd-Wrapper.
+
+    Mit Family (8.4) wird die aktive Patch-Version übernommen.
+    Mit voller Version (8.4.19) wird exakt diese Version dauerhaft aktiviert.
+    """
     prefix: Path = ctx.obj["prefix"]
     family = family_from_version(version_spec)
-    sf = state_file(prefix, family)
-    state = get_family_state(sf)
 
-    if not state.get("active"):
-        click.echo(f"PHP {family} ist nicht installiert. Zuerst: pbrew install {family}", err=True)
-        raise SystemExit(1)
+    if _is_pinned(version_spec):
+        vdir = version_dir(prefix, version_spec)
+        if not vdir.exists():
+            click.echo(
+                f"PHP {version_spec} ist nicht installiert. "
+                f"Zuerst: pbrew install {version_spec}",
+                err=True,
+            )
+            raise SystemExit(1)
+        version = version_spec
+        write_versioned_wrappers(prefix, version, family)
+        set_active_version(state_file(prefix, family), version)
+    else:
+        sf = state_file(prefix, family)
+        state = get_family_state(sf)
+        if not state.get("active"):
+            click.echo(
+                f"PHP {family} ist nicht installiert. Zuerst: pbrew install {family}",
+                err=True,
+            )
+            raise SystemExit(1)
+        version = state["active"]
 
-    version = state["active"]
     set_global_default(global_state_file(prefix), family)
     write_naked_wrappers(prefix, version, family)
     click.echo(f"✓ php{family_suffix(family)} ist jetzt der permanente Default")

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -5,21 +5,34 @@ from click.testing import CliRunner
 from pbrew.cli import main
 
 
-def _setup(prefix, family, active_version, config_name=None):
-    """Legt einen minimalen installierten State an."""
-    vdir = prefix / "versions" / active_version
-    (vdir / "bin").mkdir(parents=True)
-    (vdir / "bin" / "php").write_text("#!/bin/bash\n")
+def _make_prefix(prefix, families: dict):
+    """families = {family: {version: config_name or None, ...}, active_version: str}
 
+    Kurzform: {family: [v1, v2]} → erste Version ist aktiv, config_name=None
+    """
     state_dir = prefix / "state"
     state_dir.mkdir(parents=True, exist_ok=True)
-    installed_entry = {}
-    if config_name:
-        installed_entry["config_name"] = config_name
-    (state_dir / f"{family}.json").write_text(json.dumps({
-        "active": active_version,
-        "installed": {active_version: installed_entry},
-    }))
+
+    for family, spec in families.items():
+        if isinstance(spec, list):
+            versions = spec
+            active = versions[0]
+            config_map = {v: None for v in versions}
+        else:
+            versions = list(spec["versions"].keys())
+            active = spec["active"]
+            config_map = spec["versions"]
+
+        for v in versions:
+            vdir = prefix / "versions" / v
+            (vdir / "bin").mkdir(parents=True, exist_ok=True)
+            (vdir / "bin" / "php").write_text("#!/bin/bash\n")
+
+        installed = {v: ({"config_name": c} if c else {}) for v, c in config_map.items()}
+        (state_dir / f"{family}.json").write_text(json.dumps({
+            "active": active,
+            "installed": installed,
+        }))
 
 
 def _invoke(prefix, tmp_path):
@@ -33,7 +46,7 @@ def _invoke(prefix, tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_list_shows_config_column(tmp_path):
-    _setup(tmp_path, "8.4", "8.4.22", config_name="dev")
+    _make_prefix(tmp_path, {"8.4": {"versions": {"8.4.22": "dev"}, "active": "8.4.22"}})
     result = _invoke(tmp_path, tmp_path)
     assert result.exit_code == 0, result.output
     assert "Config" in result.output
@@ -42,7 +55,7 @@ def test_list_shows_config_column(tmp_path):
 
 def test_list_shows_dash_for_legacy_install_without_config(tmp_path):
     """Installs ohne config_name zeigen — in der Config-Spalte."""
-    _setup(tmp_path, "8.3", "8.3.10")  # kein config_name
+    _make_prefix(tmp_path, {"8.3": ["8.3.10"]})
     result = _invoke(tmp_path, tmp_path)
     assert result.exit_code == 0, result.output
     assert "8.3.10" in result.output
@@ -51,10 +64,78 @@ def test_list_shows_dash_for_legacy_install_without_config(tmp_path):
 
 def test_list_shows_correct_config_per_family(tmp_path):
     """Mehrere Familien mit unterschiedlichen Configs zeigen korrekt an."""
-    _setup(tmp_path, "8.4", "8.4.22", config_name="dev")
-    _setup(tmp_path, "8.3", "8.3.10", config_name="prod")
+    _make_prefix(tmp_path, {
+        "8.4": {"versions": {"8.4.22": "dev"}, "active": "8.4.22"},
+        "8.3": {"versions": {"8.3.10": "prod"}, "active": "8.3.10"},
+    })
     result = _invoke(tmp_path, tmp_path)
     assert result.exit_code == 0, result.output
-    # Beide Configs müssen im Output erscheinen
     assert "dev" in result.output
     assert "prod" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Alle installierten Versionen einer Family erscheinen
+# ---------------------------------------------------------------------------
+
+def test_list_shows_all_versions_in_family(tmp_path):
+    """Beide 8.4-Versionen müssen im Output erscheinen."""
+    _make_prefix(tmp_path, {
+        "8.4": {
+            "versions": {"8.4.19": "default", "8.4.20": "default"},
+            "active": "8.4.19",
+        },
+    })
+    result = _invoke(tmp_path, tmp_path)
+    assert result.exit_code == 0, result.output
+    assert "8.4.19" in result.output
+    assert "8.4.20" in result.output
+
+
+def test_list_marks_active_version(tmp_path):
+    """Die aktive Version ist mit ▸ markiert."""
+    _make_prefix(tmp_path, {
+        "8.4": {
+            "versions": {"8.4.19": "default", "8.4.20": "default"},
+            "active": "8.4.19",
+        },
+    })
+    result = _invoke(tmp_path, tmp_path)
+    assert result.exit_code == 0, result.output
+    lines = result.output.splitlines()
+    active_line = next(l for l in lines if "8.4.19" in l)
+    inactive_line = next(l for l in lines if "8.4.20" in l)
+    assert "▸" in active_line
+    assert "▸" not in inactive_line
+
+
+def test_list_shows_family_once_for_multiple_versions(tmp_path):
+    """Der Family-Name erscheint nur in der ersten Zeile der Gruppe."""
+    _make_prefix(tmp_path, {
+        "8.4": {
+            "versions": {"8.4.19": "default", "8.4.20": "default"},
+            "active": "8.4.19",
+        },
+    })
+    result = _invoke(tmp_path, tmp_path)
+    assert result.exit_code == 0, result.output
+    lines = result.output.splitlines()
+    # Versionen sind absteigend sortiert: 8.4.20 ist die erste Zeile (Family-Label)
+    first_row = next(l for l in lines if "8.4.20" in l)
+    second_row = next(l for l in lines if "8.4.19" in l)
+    assert first_row.startswith("  8.4 ")
+    assert not second_row.startswith("  8.4 ")
+
+
+def test_list_shows_config_per_version(tmp_path):
+    """Jede Version zeigt ihre eigene Config."""
+    _make_prefix(tmp_path, {
+        "8.4": {
+            "versions": {"8.4.19": "production", "8.4.20": "dev"},
+            "active": "8.4.19",
+        },
+    })
+    result = _invoke(tmp_path, tmp_path)
+    assert result.exit_code == 0, result.output
+    assert "production" in result.output
+    assert "dev" in result.output

--- a/tests/test_use_switch.py
+++ b/tests/test_use_switch.py
@@ -1,0 +1,103 @@
+"""Tests für pbrew use und pbrew switch mit Family- und Patch-Version."""
+import json
+import os
+from pathlib import Path
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+
+
+def _make_prefix(tmp_path: Path, family: str, versions: list[str], active: str) -> Path:
+    prefix = tmp_path / "pbrew"
+    state_dir = prefix / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    for v in versions:
+        vdir = prefix / "versions" / v
+        (vdir / "bin").mkdir(parents=True, exist_ok=True)
+        (vdir / "bin" / "php").write_text("#!/bin/bash\n")
+        (vdir / "bin" / "php").chmod(0o755)
+
+    installed = {v: {"config_name": "default"} for v in versions}
+    (state_dir / f"{family}.json").write_text(json.dumps({
+        "active": active,
+        "installed": installed,
+    }))
+
+    # Bin-Dir mit versioned wrapper anlegen
+    bin_dir = prefix / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+
+    return prefix
+
+
+def _invoke(prefix, args):
+    runner = CliRunner()
+    with patch.dict(os.environ, {"XDG_CONFIG_HOME": str(prefix.parent / "config")}):
+        return runner.invoke(main, ["--prefix", str(prefix)] + args)
+
+
+# ---------------------------------------------------------------------------
+# pbrew use: Family-Angabe (bisheriges Verhalten)
+# ---------------------------------------------------------------------------
+
+def test_use_family_exports_pbrew_bin(tmp_path):
+    prefix = _make_prefix(tmp_path, "8.4", ["8.4.19"], "8.4.19")
+    result = _invoke(prefix, ["use", "8.4"])
+    assert result.exit_code == 0, result.output
+    assert "bin" in result.output
+    assert "hash -r" in result.output
+
+
+# ---------------------------------------------------------------------------
+# pbrew use: Gepinnte Patch-Version → direkter Pfad in PATH
+# ---------------------------------------------------------------------------
+
+def test_use_pinned_version_exports_version_bin_path(tmp_path):
+    """pbrew use 8.4.19 muss versions/8.4.19/bin in PATH exportieren."""
+    prefix = _make_prefix(tmp_path, "8.4", ["8.4.19", "8.4.20"], "8.4.20")
+    result = _invoke(prefix, ["use", "8.4.19"])
+    assert result.exit_code == 0, result.output
+    assert "8.4.19" in result.output
+    assert "versions" in result.output
+    assert "hash -r" in result.output
+
+
+def test_use_pinned_version_not_installed_fails(tmp_path):
+    prefix = _make_prefix(tmp_path, "8.4", ["8.4.19"], "8.4.19")
+    result = _invoke(prefix, ["use", "8.4.99"])
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# pbrew switch: Gepinnte Patch-Version → Wrapper + State aktualisieren
+# ---------------------------------------------------------------------------
+
+def test_switch_pinned_version_updates_state(tmp_path):
+    """pbrew switch 8.4.19 setzt 8.4.19 als active in state."""
+    prefix = _make_prefix(tmp_path, "8.4", ["8.4.19", "8.4.20"], "8.4.20")
+    with patch("pbrew.cli.use.write_naked_wrappers"), \
+         patch("pbrew.cli.use.write_versioned_wrappers"):
+        result = _invoke(prefix, ["switch", "8.4.19"])
+    assert result.exit_code == 0, result.output
+    state = json.loads((prefix / "state" / "8.4.json").read_text())
+    assert state["active"] == "8.4.19"
+
+
+def test_switch_pinned_version_not_installed_fails(tmp_path):
+    prefix = _make_prefix(tmp_path, "8.4", ["8.4.19"], "8.4.19")
+    result = _invoke(prefix, ["switch", "8.4.99"])
+    assert result.exit_code != 0
+
+
+def test_switch_family_uses_active_version(tmp_path):
+    """pbrew switch 8.4 nutzt weiterhin state.active."""
+    prefix = _make_prefix(tmp_path, "8.4", ["8.4.19", "8.4.20"], "8.4.20")
+    with patch("pbrew.cli.use.write_naked_wrappers") as mock_wrap, \
+         patch("pbrew.cli.use.write_versioned_wrappers"):
+        result = _invoke(prefix, ["switch", "8.4"])
+    assert result.exit_code == 0, result.output
+    # php-Wrapper wird mit der aktiven Version aufgerufen
+    mock_wrap.assert_called_once()
+    _, call_args, _ = mock_wrap.mock_calls[0]
+    assert "8.4.20" in call_args


### PR DESCRIPTION
## Summary

- `pbrew list` zeigt jede installierte Patch-Version in einer eigenen Zeile (▸ = aktiv)
- `pbrew use 8.4.19` exportiert `versions/8.4.19/bin` session-lokal in PATH
- `pbrew switch 8.4.19` aktualisiert `php84`-Wrapper + State dauerhaft

## Vorher / Nachher

**Vorher:** Eine Zeile pro Family, "Vorherige"-Spalte, keine anderen Versionen sichtbar.

**Nachher:** Eine Zeile pro installierter Version, ▸ markiert die aktive, neueste oben.

## Test Plan
- [ ] `pbrew list` zeigt beide Versionen, aktive mit ▸
- [ ] `pbrew use 8.4.19` → PATH enthält versions/8.4.19/bin
- [ ] `pbrew switch 8.4.19` → php84 zeigt auf 8.4.19
- [ ] 13 Tests grün

Closes #69