### PR TITLE
[77] ext list: vollständige Übersicht + ext installed

### DIFF
--- a/pbrew/cli/__init__.py
+++ b/pbrew/cli/__init__.py
@@ -17,7 +17,7 @@ from pbrew.cli.info import info_cmd
 from pbrew.cli.env import env_cmd
 from pbrew.cli.outdated import outdated_cmd
 from pbrew.cli.fpm import fpm_cmd
-from pbrew.cli.ext import ext_cmd, extension_cmd
+from pbrew.cli.ext import ext_cmd
 from pbrew.cli.upgrade import upgrade_cmd, rollback_cmd
 from pbrew.cli.config_ import config_cmd
 from pbrew.cli.test_ import test_cmd
@@ -81,7 +81,6 @@ main.add_command(env_cmd, name="env")
 main.add_command(outdated_cmd, name="outdated")
 main.add_command(fpm_cmd, name="fpm")
 main.add_command(ext_cmd, name="ext")
-main.add_command(extension_cmd, name="extension")
 main.add_command(upgrade_cmd, name="upgrade")
 main.add_command(rollback_cmd, name="rollback")
 main.add_command(config_cmd, name="config")

--- a/pbrew/cli/ext.py
+++ b/pbrew/cli/ext.py
@@ -182,25 +182,77 @@ def disable_ext_cmd(ctx, ext_name, version_spec):
     click.echo(f"✓ {ext_name} deaktiviert.")
 
 
-@ext_cmd.command("list")
+@ext_cmd.command("installed")
 @click.argument("version_spec", required=False)
 @click.pass_context
-def list_ext_cmd(ctx, version_spec):
-    """Listet installierte Extensions für eine PHP-Family."""
+def installed_ext_cmd(ctx, version_spec):
+    """Zeigt nur pbrew-verwaltete Extensions (aktiv und inaktiv)."""
     prefix: Path = ctx.obj["prefix"]
     family = _resolve_family(prefix, version_spec)
     confd = prefix / "etc" / "conf.d" / family
     if not confd.exists():
         click.echo(f"Kein scan-dir für PHP {family} gefunden.")
         return
-    click.echo(f"\nExtensions für PHP {family} ({confd}):")
+    click.echo(f"\nPbrew-Extensions für PHP {family}:")
     for ini in sorted(confd.glob("*.ini")):
-        click.echo(f"  [aktiv]    {ini.stem}")
+        if ini.stem != "00-base":
+            click.echo(f"  [aktiv]    {ini.stem}")
     for ini in sorted(confd.glob("*.ini.disabled")):
-        # stem gibt hier "{name}.ini" zurück – das .ini entfernen
         name = ini.name.removesuffix(".ini.disabled")
         click.echo(f"  [inaktiv]  {name}")
     click.echo()
+
+
+@ext_cmd.command("list")
+@click.argument("version_spec", required=False)
+@click.pass_context
+def list_ext_cmd(ctx, version_spec):
+    """Vollständige Extension-Übersicht: geladen, verfügbar und Standard."""
+    prefix: Path = ctx.obj["prefix"]
+    family = _resolve_family(prefix, version_spec)
+    php_version = _resolve_active_version(prefix, family)
+    php_bin = version_bin(prefix, php_version, "php")
+
+    if not php_bin.exists():
+        click.echo(f"PHP-Binary nicht gefunden: {php_bin}", err=True)
+        raise SystemExit(1)
+
+    confd = prefix / "etc" / "conf.d" / family
+    pbrew_active: set[str] = set()
+    pbrew_disabled: set[str] = set()
+    if confd.exists():
+        for ini in confd.glob("*.ini"):
+            if ini.stem != "00-base":
+                pbrew_active.add(ini.stem.lower())
+        for ini in confd.glob("*.ini.disabled"):
+            pbrew_disabled.add(ini.name.removesuffix(".ini.disabled").lower())
+
+    loaded, local, standard = _query_extensions(php_bin)
+
+    col_width = max((len(name) for _, (name, _) in loaded.items()), default=10) + 2
+
+    click.echo(f"\nExtensions für PHP {family}:\n")
+    click.echo("Loaded extensions:")
+    for _, (name, version) in sorted(loaded.items()):
+        marker = "  [pbrew]" if name.lower() in pbrew_active else ""
+        click.echo(f" [*] {name:<{col_width}} {version}{marker}")
+
+    if local or pbrew_disabled:
+        click.echo("Available local extensions:")
+        shown_lower: set[str] = set()
+        for name in local:
+            shown_lower.add(name.lower())
+            if name.lower() in pbrew_disabled:
+                click.echo(f" [-] {name:<{col_width}}  [pbrew, inaktiv]")
+            else:
+                click.echo(f" [ ] {name}")
+        for name in sorted(pbrew_disabled - shown_lower):
+            click.echo(f" [-] {name:<{col_width}}  [pbrew, inaktiv]")
+
+    if standard:
+        click.echo("Standard extensions (not compiled):")
+        for name in standard:
+            click.echo(f" [ ] {name}")
 
 
 # Vollständige Liste der Standard-PHP-Extensions (alle PHP-Versionen ≥ 7.4)
@@ -258,39 +310,6 @@ def _query_extensions(
     )
 
     return loaded, local, standard
-
-
-@click.command("extension")
-@click.argument("version_spec", required=False)
-@click.pass_context
-def extension_cmd(ctx, version_spec):
-    """Zeigt geladene und verfügbare PHP-Extensions (wie phpbrew extension)."""
-    prefix: Path = ctx.obj["prefix"]
-    family = _resolve_family(prefix, version_spec)
-    php_version = _resolve_active_version(prefix, family)
-    php_bin = version_bin(prefix, php_version, "php")
-
-    if not php_bin.exists():
-        click.echo(f"PHP-Binary nicht gefunden: {php_bin}", err=True)
-        raise SystemExit(1)
-
-    loaded, local, standard = _query_extensions(php_bin)
-
-    col_width = max((len(name) for _, (name, _) in loaded.items()), default=10) + 2
-
-    click.echo("Loaded extensions:")
-    for _, (name, version) in sorted(loaded.items()):
-        click.echo(f" [*] {name:<{col_width}} {version}")
-
-    if local:
-        click.echo("Available local extensions:")
-        for name in local:
-            click.echo(f" [ ] {name}")
-
-    if standard:
-        click.echo("Standard extensions (not compiled):")
-        for name in standard:
-            click.echo(f" [ ] {name}")
 
 
 def _resolve_family(prefix: Path, version_spec: "str | None") -> str:

--- a/tests/test_ext_cli.py
+++ b/tests/test_ext_cli.py
@@ -39,7 +39,7 @@ def test_ext_list_shows_active_and_inactive(tmp_path):
     _setup_version(tmp_path)
     _write_ini(tmp_path, "8.4", "apcu")
     _write_ini(tmp_path, "8.4", "xdebug", disabled=True)
-    result = _invoke(tmp_path, tmp_path, "ext", "list", "8.4")
+    result = _invoke(tmp_path, tmp_path, "ext", "installed", "8.4")
     assert result.exit_code == 0, result.output
     assert "apcu" in result.output
     assert "xdebug" in result.output
@@ -49,7 +49,7 @@ def test_ext_list_shows_active_and_inactive(tmp_path):
 
 def test_ext_list_without_scan_dir(tmp_path):
     _setup_version(tmp_path)
-    result = _invoke(tmp_path, tmp_path, "ext", "list", "8.4")
+    result = _invoke(tmp_path, tmp_path, "ext", "installed", "8.4")
     assert result.exit_code == 0
     assert "Kein scan-dir" in result.output
 
@@ -118,7 +118,7 @@ def test_family_resolved_from_pbrew_active(tmp_path):
     """Ohne explizites Argument wird PBREW_ACTIVE verwendet (neue Architektur)."""
     _setup_version(tmp_path)
     _write_ini(tmp_path, "8.4", "apcu")
-    result = _invoke(tmp_path, tmp_path, "ext", "list", env_extra={"PBREW_ACTIVE": "8.4.22"})
+    result = _invoke(tmp_path, tmp_path, "ext", "installed", env_extra={"PBREW_ACTIVE": "8.4.22"})
     assert result.exit_code == 0
     assert "apcu" in result.output
 
@@ -127,7 +127,7 @@ def test_family_resolved_from_pbrew_php_fallback(tmp_path):
     """PBREW_PHP wird als Fallback akzeptiert, wenn PBREW_ACTIVE nicht gesetzt."""
     _setup_version(tmp_path)
     _write_ini(tmp_path, "8.4", "apcu")
-    result = _invoke(tmp_path, tmp_path, "ext", "list", env_extra={"PBREW_PHP": "8.4"})
+    result = _invoke(tmp_path, tmp_path, "ext", "installed", env_extra={"PBREW_PHP": "8.4"})
     assert result.exit_code == 0
     assert "apcu" in result.output
 
@@ -137,7 +137,7 @@ def test_family_resolved_from_global_state(tmp_path):
     _setup_version(tmp_path)
     _write_ini(tmp_path, "8.4", "apcu")
     # Kein PBREW_PHP; global state hat default_family=8.4
-    result = _invoke(tmp_path, tmp_path, "ext", "list")
+    result = _invoke(tmp_path, tmp_path, "ext", "installed")
     assert result.exit_code == 0, result.output
     assert "apcu" in result.output
 
@@ -145,6 +145,6 @@ def test_family_resolved_from_global_state(tmp_path):
 def test_family_error_without_any_hint(tmp_path):
     """Keine Argumente, kein Env, kein Global → Fehler mit Hinweis."""
     # Kein setup – also auch kein global.json mit default_family
-    result = _invoke(tmp_path, tmp_path, "ext", "list")
+    result = _invoke(tmp_path, tmp_path, "ext", "installed")
     assert result.exit_code != 0
     assert "Keine aktive PHP-Version" in result.output

--- a/tests/test_extension_cmd.py
+++ b/tests/test_extension_cmd.py
@@ -22,7 +22,7 @@ def _setup_version(prefix, family="8.4", version="8.4.22"):
 
 def _fake_ext_dir(tmp_path: Path, so_names: list[str]) -> Path:
     ext_dir = tmp_path / "ext_dir"
-    ext_dir.mkdir()
+    ext_dir.mkdir(exist_ok=True)
     for name in so_names:
         (ext_dir / f"{name}.so").touch()
     return ext_dir
@@ -48,16 +48,16 @@ def _invoke(prefix, tmp_path, *args, env_extra=None):
 
 
 # ---------------------------------------------------------------------------
-# Grundlegende Ausgabe
+# ext list – kombinierte Ansicht
 # ---------------------------------------------------------------------------
 
-def test_extension_shows_loaded_extensions(tmp_path):
-    php_bin = _setup_version(tmp_path)
+def test_ext_list_shows_loaded_extensions(tmp_path):
+    _setup_version(tmp_path)
     ext_dir = _fake_ext_dir(tmp_path, [])
     ext_output = "apcu|5.1.24\nbcmath|8.4.22\n"
 
     with patch("pbrew.cli.ext.subprocess.run", side_effect=_make_run(ext_output, ext_dir)):
-        result = _invoke(tmp_path, tmp_path, "extension", "8.4")
+        result = _invoke(tmp_path, tmp_path, "ext", "list", "8.4")
 
     assert result.exit_code == 0, result.output
     assert "Loaded extensions:" in result.output
@@ -67,77 +67,133 @@ def test_extension_shows_loaded_extensions(tmp_path):
     assert "bcmath" in result.output
 
 
-def test_extension_shows_available_extensions(tmp_path):
-    php_bin = _setup_version(tmp_path)
+def test_ext_list_shows_available_local_extensions(tmp_path):
+    _setup_version(tmp_path)
     # dba ist im extension_dir, aber nicht geladen
     ext_dir = _fake_ext_dir(tmp_path, ["dba", "ldap"])
     ext_output = "apcu|5.1.24\n"
 
     with patch("pbrew.cli.ext.subprocess.run", side_effect=_make_run(ext_output, ext_dir)):
-        result = _invoke(tmp_path, tmp_path, "extension", "8.4")
+        result = _invoke(tmp_path, tmp_path, "ext", "list", "8.4")
 
     assert result.exit_code == 0, result.output
     assert "Available local extensions:" in result.output
-    assert "[ ]" in result.output
     assert "dba" in result.output
     assert "ldap" in result.output
 
 
-def test_extension_no_available_section_when_all_loaded(tmp_path):
+def test_ext_list_marks_pbrew_loaded_extension(tmp_path):
+    _setup_version(tmp_path)
+    ext_dir = _fake_ext_dir(tmp_path, [])
+    ext_output = "apcu|5.1.24\n"
+    # apcu hat eine aktive pbrew-INI
+    confd = tmp_path / "etc" / "conf.d" / "8.4"
+    confd.mkdir(parents=True)
+    (confd / "apcu.ini").write_text("extension=apcu.so\n")
+
+    with patch("pbrew.cli.ext.subprocess.run", side_effect=_make_run(ext_output, ext_dir)):
+        result = _invoke(tmp_path, tmp_path, "ext", "list", "8.4")
+
+    assert result.exit_code == 0, result.output
+    assert "[pbrew]" in result.output
+
+
+def test_ext_list_marks_pbrew_disabled_extension(tmp_path):
+    _setup_version(tmp_path)
+    ext_dir = _fake_ext_dir(tmp_path, ["apcu"])
+    ext_output = "json|8.4.22\n"
+    # apcu ist deaktiviert
+    confd = tmp_path / "etc" / "conf.d" / "8.4"
+    confd.mkdir(parents=True)
+    (confd / "apcu.ini.disabled").write_text("extension=apcu.so\n")
+
+    with patch("pbrew.cli.ext.subprocess.run", side_effect=_make_run(ext_output, ext_dir)):
+        result = _invoke(tmp_path, tmp_path, "ext", "list", "8.4")
+
+    assert result.exit_code == 0, result.output
+    assert "[-]" in result.output
+    assert "pbrew, inaktiv" in result.output
+
+
+def test_ext_list_no_local_section_when_all_loaded(tmp_path):
     _setup_version(tmp_path)
     ext_dir = _fake_ext_dir(tmp_path, ["apcu"])
     ext_output = "apcu|5.1.24\n"
 
     with patch("pbrew.cli.ext.subprocess.run", side_effect=_make_run(ext_output, ext_dir)):
-        result = _invoke(tmp_path, tmp_path, "extension", "8.4")
+        result = _invoke(tmp_path, tmp_path, "ext", "list", "8.4")
 
     assert result.exit_code == 0, result.output
     assert "Available local extensions:" not in result.output
 
 
-def test_extension_uses_global_default_family(tmp_path):
+def test_ext_list_shows_standard_extensions(tmp_path):
     _setup_version(tmp_path)
     ext_dir = _fake_ext_dir(tmp_path, [])
     ext_output = "json|8.4.22\n"
 
     with patch("pbrew.cli.ext.subprocess.run", side_effect=_make_run(ext_output, ext_dir)):
-        result = _invoke(tmp_path, tmp_path, "extension")
-
-    assert result.exit_code == 0, result.output
-    assert "json" in result.output
-
-
-def test_extension_shows_standard_extensions_not_compiled(tmp_path):
-    _setup_version(tmp_path)
-    ext_dir = _fake_ext_dir(tmp_path, [])
-    # Nur json ist geladen; gmp und mbstring sind Standard-Extensions, aber nicht geladen
-    ext_output = "json|8.4.22\n"
-
-    with patch("pbrew.cli.ext.subprocess.run", side_effect=_make_run(ext_output, ext_dir)):
-        result = _invoke(tmp_path, tmp_path, "extension", "8.4")
+        result = _invoke(tmp_path, tmp_path, "ext", "list", "8.4")
 
     assert result.exit_code == 0, result.output
     assert "Standard extensions (not compiled):" in result.output
     assert "gmp" in result.output
     assert "mbstring" in result.output
-    # json ist geladen, darf nicht in der Standard-Liste erscheinen
-    loaded_section_end = result.output.index("Standard extensions")
-    assert result.output.count("json") == 1  # nur einmal in Loaded, nicht nochmal
+    # json ist geladen, darf nicht nochmal in Standard erscheinen
+    assert result.output.count("json") == 1
 
 
-def test_extension_error_when_no_active_version(tmp_path):
-    result = _invoke(tmp_path, tmp_path, "extension")
+def test_ext_list_uses_global_default_family(tmp_path):
+    _setup_version(tmp_path)
+    ext_dir = _fake_ext_dir(tmp_path, [])
+    ext_output = "json|8.4.22\n"
+
+    with patch("pbrew.cli.ext.subprocess.run", side_effect=_make_run(ext_output, ext_dir)):
+        result = _invoke(tmp_path, tmp_path, "ext", "list")
+
+    assert result.exit_code == 0, result.output
+    assert "json" in result.output
+
+
+def test_ext_list_error_when_no_active_version(tmp_path):
+    result = _invoke(tmp_path, tmp_path, "ext", "list")
     assert result.exit_code != 0
     assert "Keine aktive PHP-Version" in result.output
 
 
-def test_extension_error_when_php_binary_missing(tmp_path):
-    # Version im State, aber kein Binary auf Disk
+def test_ext_list_error_when_php_binary_missing(tmp_path):
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     (state_dir / "8.4.json").write_text(json.dumps({"active": "8.4.22"}))
     (state_dir / "global.json").write_text(json.dumps({"default_family": "8.4"}))
 
-    result = _invoke(tmp_path, tmp_path, "extension", "8.4")
+    result = _invoke(tmp_path, tmp_path, "ext", "list", "8.4")
     assert result.exit_code != 0
     assert "nicht gefunden" in result.output
+
+
+# ---------------------------------------------------------------------------
+# ext installed – nur pbrew-verwaltete Extensions
+# ---------------------------------------------------------------------------
+
+def test_ext_installed_shows_active_and_inactive(tmp_path):
+    _setup_version(tmp_path)
+    confd = tmp_path / "etc" / "conf.d" / "8.4"
+    confd.mkdir(parents=True)
+    (confd / "apcu.ini").write_text("extension=apcu.so\n")
+    (confd / "xdebug.ini.disabled").write_text("zend_extension=xdebug.so\n")
+
+    result = _invoke(tmp_path, tmp_path, "ext", "installed", "8.4")
+
+    assert result.exit_code == 0, result.output
+    assert "apcu" in result.output
+    assert "xdebug" in result.output
+    assert "aktiv" in result.output
+    assert "inaktiv" in result.output
+
+
+def test_ext_installed_without_scan_dir(tmp_path):
+    _setup_version(tmp_path)
+    result = _invoke(tmp_path, tmp_path, "ext", "installed", "8.4")
+    assert result.exit_code == 0
+    assert "Kein scan-dir" in result.output


### PR DESCRIPTION
## Summary

- `ext list` → vollständige Extension-Übersicht (Loaded / Available local / Standard), ersetzt `pbrew extension`
- `ext installed` → neu, zeigt nur pbrew-verwaltete Extensions (bisheriges `ext list`, schnell ohne PHP-Subprocess)
- `pbrew extension` → entfernt
- pbrew-verwaltete Extensions in `ext list` mit `[pbrew]` (aktiv) und `[pbrew, inaktiv]` (disabled INI) markiert

## Test plan

- [ ] `pytest tests/test_ext_cli.py tests/test_extension_cmd.py -v` – 23 Tests grün
- [ ] Manuell: `pbrew ext list` zeigt drei Sektionen mit pbrew-Markern
- [ ] Manuell: `pbrew ext installed` zeigt nur pbrew-INIs

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)