### PR TITLE
[79] pbrew ext add / ext remove interaktiv

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -3,3 +3,13 @@
 ## Architektur & Konventionen
 
 ## Bekannte Fallen & Gotchas
+
+### questionary in Tests
+
+Beim Testen von Funktionen, die `questionary` verwenden, immer `unittest.mock.patch` auf den Modulpfad `pbrew.cli.ext.questionary.checkbox` / `.select` / `.text` anwenden – nicht auf `questionary.*` global. Nur so greift der Patch in der richtigen Import-Namespace-Kopie.
+
+Zusätzlich `_is_tty` via `patch("pbrew.cli.ext._is_tty", return_value=True)` mocken, nicht `sys.stdin.isatty` direkt – der Click `CliRunner` ersetzt `sys.stdin`, sodass ein Patch auf `sys.stdin.isatty` ins Leere greift.
+
+### VARIANT_FLAGS / VARIANT_EXTENSIONS
+
+`_VARIANT_FLAGS` ist jetzt öffentlich als `VARIANT_FLAGS` exportiert. SAPI-Einträge (`cli`, `fpm`, `fpm-systemd`) sind in `VARIANT_EXTENSIONS` nicht enthalten – `VARIANT_EXTENSIONS` listet ausschließlich echte Extension-Varianten. Bei Iterationen über Extension-Varianten immer `VARIANT_EXTENSIONS` verwenden, nicht `VARIANT_FLAGS`.

--- a/pbrew/cli/ext.py
+++ b/pbrew/cli/ext.py
@@ -320,6 +320,32 @@ def _query_extensions(
     return loaded, local, standard
 
 
+def _collect_add_candidates(
+    *,
+    loaded: dict[str, tuple[str, str]],
+    local: list[str],
+    standard: list[str],
+    pbrew_active: set[str],
+    active_variants: set[str],
+) -> tuple[list[str], list[str], list[str]]:
+    from pbrew.core.builder import VARIANT_EXTENSIONS
+
+    local_candidates = [n for n in local if n.lower() not in pbrew_active]
+
+    known = {n.lower() for n in loaded}
+    known |= {n.lower() for n in local}
+    known |= {n.lower() for n in standard}
+    pecl_candidates = sorted(
+        n for n in _PECL_SUGGESTIONS if n.lower() not in known
+    )
+
+    rebuild_candidates = sorted(
+        n for n in standard
+        if n in VARIANT_EXTENSIONS and n not in active_variants
+    )
+    return local_candidates, pecl_candidates, rebuild_candidates
+
+
 def _resolve_family(prefix: Path, version_spec: "str | None") -> str:
     if version_spec:
         return family_from_version(version_spec)

--- a/pbrew/cli/ext.py
+++ b/pbrew/cli/ext.py
@@ -2,6 +2,7 @@ import subprocess
 from pathlib import Path
 
 import click
+import questionary
 import tomlkit
 
 from pbrew.core.paths import (
@@ -380,6 +381,31 @@ def _remove_config_variants(config_path: Path, variants: list[str]) -> list[str]
     build["variants"] = current
     config_path.write_text(tomlkit.dumps(doc))
     return removed
+
+
+def _prompt_config_choice(configs_dir: Path, active_family: str) -> "Path | None":
+    """Fragt nach der Ziel-Config. Gibt None bei Abbruch zurück."""
+    existing = sorted(p.name for p in configs_dir.glob("*.toml"))
+    choices = existing + ["<neu>"]
+    label = (
+        f"In welche Config sollen die Variants fuer PHP {active_family} "
+        f"eingetragen werden?"
+    )
+    pick = questionary.select(label, choices=choices).ask()
+    if pick is None:
+        return None
+    if pick == "<neu>":
+        name = questionary.text(
+            "Name der neuen Config (a-z, 0-9, _ und -):"
+        ).ask()
+        if not name:
+            return None
+        import re
+        if not re.fullmatch(r"[a-zA-Z0-9_\-]+", name):
+            click.echo(f"Ungueltiger Name: {name!r}", err=True)
+            return None
+        return configs_dir / f"{name}.toml"
+    return configs_dir / pick
 
 
 def _resolve_family(prefix: Path, version_spec: "str | None") -> str:

--- a/pbrew/cli/ext.py
+++ b/pbrew/cli/ext.py
@@ -135,23 +135,119 @@ def install_ext_cmd(ctx, ext_name, version_spec, ext_version, jobs):
 
 
 @ext_cmd.command("remove")
-@click.argument("ext_name")
+@click.argument("ext_name", required=False)
 @click.argument("version_spec", required=False)
 @click.pass_context
 def remove_ext_cmd(ctx, ext_name, version_spec):
-    """Deaktiviert eine Extension (verschiebt INI zu .disabled)."""
+    """Deaktiviert/entfernt Extensions. Ohne EXT interaktiv."""
+    # Wenn nur ein Argument übergeben wurde und es wie eine PHP-Version
+    # aussieht (z.B. "8.4", "84", "8.3.1"), wird interaktiver Modus
+    # gestartet und das Argument als version_spec interpretiert.
+    import re as _re
+    if ext_name and not version_spec and _re.fullmatch(r"\d+\.?\d*\.?\d*", ext_name):
+        version_spec = ext_name
+        ext_name = None
+
+    if ext_name:
+        prefix: Path = ctx.obj["prefix"]
+        family = _resolve_family(prefix, version_spec)
+        ini = prefix / "etc" / "conf.d" / family / f"{ext_name}.ini"
+        if not ini.exists():
+            click.echo(f"{ext_name}.ini nicht gefunden für PHP {family}.", err=True)
+            raise SystemExit(1)
+        disabled = ini.with_suffix(".ini.disabled")
+        ini.rename(disabled)
+        if ext_name.lower() == "xdebug":
+            php_version = _resolve_active_version(prefix, family)
+            write_phpd_wrapper(prefix, php_version)
+        click.echo(f"✓ {ext_name} deaktiviert (INI: {disabled})")
+        return
+
+    _remove_ext_interactive(ctx, version_spec)
+
+
+def _remove_ext_interactive(ctx, version_spec):
+    """Interaktiver Modus für ext remove: Extensions per Auswahl entfernen."""
+    if not _is_tty():
+        click.echo("Interaktiver Modus benoetigt ein TTY.", err=True)
+        raise SystemExit(2)
+
     prefix: Path = ctx.obj["prefix"]
     family = _resolve_family(prefix, version_spec)
-    ini = prefix / "etc" / "conf.d" / family / f"{ext_name}.ini"
-    if not ini.exists():
-        click.echo(f"{ext_name}.ini nicht gefunden für PHP {family}.", err=True)
-        raise SystemExit(1)
-    disabled = ini.with_suffix(".ini.disabled")
-    ini.rename(disabled)
-    if ext_name.lower() == "xdebug":
-        php_version = _resolve_active_version(prefix, family)
-        write_phpd_wrapper(prefix, php_version)
-    click.echo(f"✓ {ext_name} deaktiviert (INI: {disabled})")
+    php_version = _resolve_active_version(prefix, family)
+    php_bin = version_bin(prefix, php_version, "php")
+
+    confd = prefix / "etc" / "conf.d" / family
+    active_inis = sorted(
+        ini.stem for ini in (confd.glob("*.ini") if confd.exists() else [])
+        if ini.stem != "00-base"
+    )
+    disabled_inis = sorted(
+        ini.name.removesuffix(".ini.disabled")
+        for ini in (confd.glob("*.ini.disabled") if confd.exists() else [])
+    )
+
+    from pbrew.core.builder import VARIANT_EXTENSIONS
+    from pbrew.core.paths import configs_dir as _cfg_dir
+    from pbrew.core.config import load_config
+    cfg_path = _cfg_dir(prefix)
+    active_cfg = load_config(cfg_path, family)
+    active_variants = set(active_cfg.get("build", {}).get("variants", []))
+
+    loaded, _local, _standard = _query_extensions(php_bin)
+    loaded_lower = {n.lower() for n in loaded}
+    compiled_variants = sorted(
+        v for v in active_variants
+        if v in VARIANT_EXTENSIONS and v.lower() in loaded_lower
+    )
+
+    groups = {
+        "Aktive pbrew-INI":     active_inis,
+        "Inaktive pbrew-INI":   disabled_inis,
+        "Kompiliert (Rebuild)": compiled_variants,
+    }
+    picked = _prompt_multiselect(
+        f"Extensions fuer PHP {family} entfernen:", groups,
+    )
+    if not picked:
+        click.echo("Nichts ausgewaehlt – abgebrochen.")
+        return
+
+    summary: list[str] = []
+
+    for name in picked.get("Aktive pbrew-INI", []):
+        ini = confd / f"{name}.ini"
+        if ini.exists():
+            ini.rename(ini.with_suffix(".ini.disabled"))
+            summary.append(f"  [deaktiviert] {name}")
+
+    for name in picked.get("Inaktive pbrew-INI", []):
+        ini = confd / f"{name}.ini.disabled"
+        if ini.exists():
+            ini.unlink()
+            summary.append(f"  [geloescht]   {name}")
+
+    rebuild_picks = picked.get("Kompiliert (Rebuild)", [])
+    if rebuild_picks:
+        target = _prompt_config_choice(cfg_path, family)
+        if target is None or not target.exists():
+            click.echo("Config-Auswahl abgebrochen oder nicht gefunden.")
+        else:
+            removed = _remove_config_variants(target, rebuild_picks)
+            if removed:
+                summary.append(
+                    f"  [rebuild]     {', '.join(removed)} "
+                    f"entfernt aus {target.name}"
+                )
+                click.echo(
+                    f"\nHinweis: PHP {family} neu bauen, damit die Aenderung "
+                    f"wirksam wird:\n  pbrew install {family} --config "
+                    f"{target.stem}"
+                )
+
+    click.echo("\nZusammenfassung:")
+    for line in summary:
+        click.echo(line)
 
 
 def _is_tty() -> bool:

--- a/pbrew/cli/ext.py
+++ b/pbrew/cli/ext.py
@@ -322,10 +322,7 @@ def add_ext_cmd(ctx, version_spec):
         if target is None:
             click.echo("Config-Auswahl abgebrochen – Rebuild-Gruppe uebersprungen.")
         else:
-            if not target.exists():
-                _update_config_variants(target, list(active_variants) + rebuild_picks)
-            else:
-                _update_config_variants(target, rebuild_picks)
+            _update_config_variants(target, rebuild_picks)
             summary.append(
                 f"  [rebuild]    {', '.join(rebuild_picks)} → {target.name}"
             )

--- a/pbrew/cli/ext.py
+++ b/pbrew/cli/ext.py
@@ -2,6 +2,7 @@ import subprocess
 from pathlib import Path
 
 import click
+import tomlkit
 
 from pbrew.core.paths import (
     family_from_version, logs_dir, state_file, version_bin,
@@ -344,6 +345,41 @@ def _collect_add_candidates(
         if n in VARIANT_EXTENSIONS and n not in active_variants
     )
     return local_candidates, pecl_candidates, rebuild_candidates
+
+
+def _update_config_variants(config_path: Path, variants: list[str]) -> list[str]:
+    """Fügt Variants additiv in eine Config-Datei ein. Erzeugt die Datei wenn nötig."""
+    if config_path.exists():
+        doc = tomlkit.loads(config_path.read_text())
+    else:
+        doc = tomlkit.document()
+    build = doc.setdefault("build", tomlkit.table())
+    current = list(build.get("variants", ["default"]))
+    added: list[str] = []
+    for v in variants:
+        if v not in current:
+            current.append(v)
+            added.append(v)
+    build["variants"] = current
+    config_path.write_text(tomlkit.dumps(doc))
+    return added
+
+
+def _remove_config_variants(config_path: Path, variants: list[str]) -> list[str]:
+    """Entfernt Variants aus einer Config-Datei. Datei muss existieren."""
+    doc = tomlkit.loads(config_path.read_text())
+    build = doc.get("build")
+    if build is None or "variants" not in build:
+        return []
+    current = list(build["variants"])
+    removed: list[str] = []
+    for v in variants:
+        if v in current:
+            current.remove(v)
+            removed.append(v)
+    build["variants"] = current
+    config_path.write_text(tomlkit.dumps(doc))
+    return removed
 
 
 def _resolve_family(prefix: Path, version_spec: "str | None") -> str:

--- a/pbrew/cli/ext.py
+++ b/pbrew/cli/ext.py
@@ -1,12 +1,16 @@
+import re
 import subprocess
+import sys
 from pathlib import Path
 
 import click
 import questionary
 import tomlkit
 
+from pbrew.core.config import load_config
+from pbrew.core.builder import VARIANT_EXTENSIONS
 from pbrew.core.paths import (
-    family_from_version, logs_dir, state_file, version_bin,
+    confd_dir, configs_dir, family_from_version, logs_dir, state_file, version_bin,
 )
 from pbrew.core.state import add_extension, get_family_state
 from pbrew.core.wrappers import write_phpd_wrapper
@@ -140,18 +144,16 @@ def install_ext_cmd(ctx, ext_name, version_spec, ext_version, jobs):
 @click.pass_context
 def remove_ext_cmd(ctx, ext_name, version_spec):
     """Deaktiviert/entfernt Extensions. Ohne EXT interaktiv."""
-    # Wenn nur ein Argument übergeben wurde und es wie eine PHP-Version
-    # aussieht (z.B. "8.4", "84", "8.3.1"), wird interaktiver Modus
-    # gestartet und das Argument als version_spec interpretiert.
-    import re as _re
-    if ext_name and not version_spec and _re.fullmatch(r"\d+\.?\d*\.?\d*", ext_name):
+    # Click kann zwei optionale Positionals nicht selbst nach Typ unterscheiden;
+    # ein einzelnes Argument das wie eine PHP-Version aussieht ist version_spec.
+    if ext_name and not version_spec and re.fullmatch(r"\d+\.?\d*\.?\d*", ext_name):
         version_spec = ext_name
         ext_name = None
 
     if ext_name:
         prefix: Path = ctx.obj["prefix"]
         family = _resolve_family(prefix, version_spec)
-        ini = prefix / "etc" / "conf.d" / family / f"{ext_name}.ini"
+        ini = confd_dir(prefix, family) / f"{ext_name}.ini"
         if not ini.exists():
             click.echo(f"{ext_name}.ini nicht gefunden für PHP {family}.", err=True)
             raise SystemExit(1)
@@ -177,20 +179,19 @@ def _remove_ext_interactive(ctx, version_spec):
     php_version = _resolve_active_version(prefix, family)
     php_bin = version_bin(prefix, php_version, "php")
 
-    confd = prefix / "etc" / "conf.d" / family
+    confd = confd_dir(prefix, family)
+    confd_files = list(confd.iterdir()) if confd.exists() else []
     active_inis = sorted(
-        ini.stem for ini in (confd.glob("*.ini") if confd.exists() else [])
-        if ini.stem != "00-base"
+        f.stem for f in confd_files
+        if f.suffix == ".ini" and f.stem != "00-base"
     )
     disabled_inis = sorted(
-        ini.name.removesuffix(".ini.disabled")
-        for ini in (confd.glob("*.ini.disabled") if confd.exists() else [])
+        f.name.removesuffix(".ini.disabled")
+        for f in confd_files
+        if f.name.endswith(".ini.disabled")
     )
 
-    from pbrew.core.builder import VARIANT_EXTENSIONS
-    from pbrew.core.paths import configs_dir as _cfg_dir
-    from pbrew.core.config import load_config
-    cfg_path = _cfg_dir(prefix)
+    cfg_path = configs_dir(prefix)
     active_cfg = load_config(cfg_path, family)
     active_variants = set(active_cfg.get("build", {}).get("variants", []))
 
@@ -217,15 +218,19 @@ def _remove_ext_interactive(ctx, version_spec):
 
     for name in picked.get("Aktive pbrew-INI", []):
         ini = confd / f"{name}.ini"
-        if ini.exists():
+        try:
             ini.rename(ini.with_suffix(".ini.disabled"))
             summary.append(f"  [deaktiviert] {name}")
+        except FileNotFoundError:
+            click.echo(f"  Warnung: {name}.ini nicht gefunden – uebersprungen.")
 
     for name in picked.get("Inaktive pbrew-INI", []):
         ini = confd / f"{name}.ini.disabled"
-        if ini.exists():
+        try:
             ini.unlink()
             summary.append(f"  [geloescht]   {name}")
+        except FileNotFoundError:
+            click.echo(f"  Warnung: {name}.ini.disabled nicht gefunden – uebersprungen.")
 
     rebuild_picks = picked.get("Kompiliert (Rebuild)", [])
     if rebuild_picks:
@@ -252,7 +257,6 @@ def _remove_ext_interactive(ctx, version_spec):
 
 def _is_tty() -> bool:
     """Prueft ob stdin ein TTY ist (separat fuer Tests mockbar)."""
-    import sys
     return sys.stdin.isatty()
 
 
@@ -270,13 +274,11 @@ def add_ext_cmd(ctx, version_spec):
     php_version = _resolve_active_version(prefix, family)
     php_bin = version_bin(prefix, php_version, "php")
 
-    from pbrew.core.paths import configs_dir as _cfg_dir
-    from pbrew.core.config import load_config
-    cfg_path = _cfg_dir(prefix)
+    cfg_path = configs_dir(prefix)
     active_cfg = load_config(cfg_path, family)
     active_variants = set(active_cfg.get("build", {}).get("variants", []))
 
-    confd = prefix / "etc" / "conf.d" / family
+    confd = confd_dir(prefix, family)
     pbrew_active = {
         ini.stem.lower()
         for ini in (confd.glob("*.ini") if confd.exists() else [])
@@ -351,7 +353,7 @@ def enable_ext_cmd(ctx, ext_name, version_spec):
     """Aktiviert eine deaktivierte Extension."""
     prefix: Path = ctx.obj["prefix"]
     family = _resolve_family(prefix, version_spec)
-    confd = prefix / "etc" / "conf.d" / family
+    confd = confd_dir(prefix, family)
     disabled = confd / f"{ext_name}.ini.disabled"
     ini = confd / f"{ext_name}.ini"
     if not disabled.exists():
@@ -373,7 +375,7 @@ def disable_ext_cmd(ctx, ext_name, version_spec):
     """Deaktiviert eine Extension (Alias für remove ohne State-Änderung)."""
     prefix: Path = ctx.obj["prefix"]
     family = _resolve_family(prefix, version_spec)
-    ini = prefix / "etc" / "conf.d" / family / f"{ext_name}.ini"
+    ini = confd_dir(prefix, family) / f"{ext_name}.ini"
     if not ini.exists():
         click.echo(f"{ext_name} ist bereits deaktiviert oder nicht installiert.")
         return
@@ -388,7 +390,7 @@ def installed_ext_cmd(ctx, version_spec):
     """Zeigt nur pbrew-verwaltete Extensions (aktiv und inaktiv)."""
     prefix: Path = ctx.obj["prefix"]
     family = _resolve_family(prefix, version_spec)
-    confd = prefix / "etc" / "conf.d" / family
+    confd = confd_dir(prefix, family)
     if not confd.exists():
         click.echo(f"Kein scan-dir für PHP {family} gefunden.")
         return
@@ -416,7 +418,7 @@ def list_ext_cmd(ctx, version_spec):
         click.echo(f"PHP-Binary nicht gefunden: {php_bin}", err=True)
         raise SystemExit(1)
 
-    confd = prefix / "etc" / "conf.d" / family
+    confd = confd_dir(prefix, family)
     pbrew_active: set[str] = set()
     pbrew_disabled: set[str] = set()
     if confd.exists():
@@ -519,8 +521,6 @@ def _collect_add_candidates(
     pbrew_active: set[str],
     active_variants: set[str],
 ) -> tuple[list[str], list[str], list[str]]:
-    from pbrew.core.builder import VARIANT_EXTENSIONS
-
     local_candidates = [n for n in local if n.lower() not in pbrew_active]
 
     known = {n.lower() for n in loaded}
@@ -589,7 +589,6 @@ def _prompt_config_choice(configs_dir: Path, active_family: str) -> "Path | None
         ).ask()
         if not name:
             return None
-        import re
         if not re.fullmatch(r"[a-zA-Z0-9_\-]+", name):
             click.echo(f"Ungueltiger Name: {name!r}", err=True)
             return None

--- a/pbrew/cli/ext.py
+++ b/pbrew/cli/ext.py
@@ -154,6 +154,102 @@ def remove_ext_cmd(ctx, ext_name, version_spec):
     click.echo(f"✓ {ext_name} deaktiviert (INI: {disabled})")
 
 
+def _is_tty() -> bool:
+    """Prueft ob stdin ein TTY ist (separat fuer Tests mockbar)."""
+    import sys
+    return sys.stdin.isatty()
+
+
+@ext_cmd.command("add")
+@click.argument("version_spec", required=False, metavar="[PHP-VERSION]")
+@click.pass_context
+def add_ext_cmd(ctx, version_spec):
+    """Interaktiv Extensions hinzufuegen (lokal aktivieren, PECL, Rebuild)."""
+    if not _is_tty():
+        click.echo("Interaktiver Modus benoetigt ein TTY.", err=True)
+        raise SystemExit(2)
+
+    prefix: Path = ctx.obj["prefix"]
+    family = _resolve_family(prefix, version_spec)
+    php_version = _resolve_active_version(prefix, family)
+    php_bin = version_bin(prefix, php_version, "php")
+
+    from pbrew.core.paths import configs_dir as _cfg_dir
+    from pbrew.core.config import load_config
+    cfg_path = _cfg_dir(prefix)
+    active_cfg = load_config(cfg_path, family)
+    active_variants = set(active_cfg.get("build", {}).get("variants", []))
+
+    confd = prefix / "etc" / "conf.d" / family
+    pbrew_active = {
+        ini.stem.lower()
+        for ini in (confd.glob("*.ini") if confd.exists() else [])
+        if ini.stem != "00-base"
+    }
+
+    loaded, local, standard = _query_extensions(php_bin)
+    local_c, pecl_c, rebuild_c = _collect_add_candidates(
+        loaded=loaded, local=local, standard=standard,
+        pbrew_active=pbrew_active, active_variants=active_variants,
+    )
+
+    groups = {
+        "Lokale .so": local_c,
+        "PECL": pecl_c,
+        "Standard (Rebuild)": rebuild_c,
+    }
+    picked = _prompt_multiselect(
+        f"Extensions fuer PHP {family} hinzufuegen:", groups,
+    )
+    if not picked:
+        click.echo("Nichts ausgewaehlt – abgebrochen.")
+        return
+
+    summary: list[str] = []
+
+    for name in picked.get("Lokale .so", []):
+        is_zend = name.lower() in _ZEND_EXTENSIONS
+        is_debug = name.lower() in _DEBUG_EXTENSIONS
+        write_ext_ini(prefix, family, name, is_zend=is_zend, debug=is_debug)
+        summary.append(f"  [aktiviert]  {name}")
+
+    for name in picked.get("PECL", []):
+        try:
+            _install_pecl_extension(ctx, name, family)
+            summary.append(f"  [installiert] {name}")
+        except SystemExit:
+            summary.append(f"  [FEHLER]     {name}")
+
+    rebuild_picks = picked.get("Standard (Rebuild)", [])
+    if rebuild_picks:
+        target = _prompt_config_choice(cfg_path, family)
+        if target is None:
+            click.echo("Config-Auswahl abgebrochen – Rebuild-Gruppe uebersprungen.")
+        else:
+            if not target.exists():
+                _update_config_variants(target, list(active_variants) + rebuild_picks)
+            else:
+                _update_config_variants(target, rebuild_picks)
+            summary.append(
+                f"  [rebuild]    {', '.join(rebuild_picks)} → {target.name}"
+            )
+            click.echo(
+                f"\nHinweis: PHP {family} neu bauen, damit die Variants "
+                f"wirksam werden:\n  pbrew install {family} --config "
+                f"{target.stem}"
+            )
+
+    click.echo("\nZusammenfassung:")
+    for line in summary:
+        click.echo(line)
+
+
+def _install_pecl_extension(ctx, ext_name: str, family: str) -> None:
+    """Wrapper um den bestehenden ext install-Flow fuer programmatische Aufrufe."""
+    ctx.invoke(install_ext_cmd, ext_name=ext_name, version_spec=family,
+               ext_version=None, jobs=None)
+
+
 @ext_cmd.command("enable")
 @click.argument("ext_name")
 @click.argument("version_spec", required=False)

--- a/pbrew/cli/ext.py
+++ b/pbrew/cli/ext.py
@@ -408,6 +408,35 @@ def _prompt_config_choice(configs_dir: Path, active_family: str) -> "Path | None
     return configs_dir / pick
 
 
+def _prompt_multiselect(
+    title: str, groups: dict[str, list[str]]
+) -> dict[str, list[str]]:
+    """Zeigt eine questionary.checkbox mit Gruppen-Separatoren.
+
+    Leere Gruppen werden mit Hinweis-Zeile dargestellt, aber nicht auswählbar.
+    Rückgabe: {Gruppenname: [gewählte Items]} – leere Gruppen nicht enthalten.
+    """
+    from questionary import Choice, Separator
+
+    choices: list = []
+    for group_name, items in groups.items():
+        choices.append(Separator(f"── {group_name} ──"))
+        if not items:
+            choices.append(Choice(title="  (keine)", disabled="leer"))
+            continue
+        for item in items:
+            choices.append(Choice(title=item, value=f"{group_name}::{item}"))
+
+    picked = questionary.checkbox(title, choices=choices).ask()
+    if not picked:
+        return {}
+    result: dict[str, list[str]] = {}
+    for key in picked:
+        group, _, item = key.partition("::")
+        result.setdefault(group, []).append(item)
+    return result
+
+
 def _resolve_family(prefix: Path, version_spec: "str | None") -> str:
     if version_spec:
         return family_from_version(version_spec)

--- a/pbrew/cli/ext.py
+++ b/pbrew/cli/ext.py
@@ -18,6 +18,14 @@ _ZEND_EXTENSIONS = {"xdebug", "opcache", "ioncube_loader"}
 # Extensions die nur in phpd (Debug-Scan-Dir) geladen werden sollen, nicht in php
 _DEBUG_EXTENSIONS = {"xdebug"}
 
+# Kuratierte Liste populärer PECL-Extensions als Vorauswahl in `ext add`.
+_PECL_SUGGESTIONS: frozenset[str] = frozenset({
+    "apcu", "ast", "ds", "event", "grpc", "igbinary", "imagick",
+    "mailparse", "memcache", "memcached", "mongodb", "msgpack",
+    "oauth", "protobuf", "rdkafka", "redis", "swoole", "uuid",
+    "uopz", "xdebug", "yaml", "zstd",
+})
+
 
 @click.group("ext")
 def ext_cmd():

--- a/pbrew/core/builder.py
+++ b/pbrew/core/builder.py
@@ -39,6 +39,15 @@ _VARIANT_FLAGS: dict[str, list[str]] = {
     "pgsql":        ["--with-pgsql", "--with-pdo-pgsql"],
 }
 
+# Öffentliche Aliase für externe Consumer (CLI-Kommandos wie `ext add`).
+VARIANT_FLAGS: dict[str, list[str]] = _VARIANT_FLAGS
+
+# Teilmenge der Variants, die echte Extensions darstellen (keine SAPI-Einträge).
+_SAPI_VARIANTS = frozenset({"cli", "fpm", "fpm-systemd"})
+VARIANT_EXTENSIONS: frozenset[str] = frozenset(
+    name for name in _VARIANT_FLAGS if name not in _SAPI_VARIANTS
+)
+
 
 def build_configure_args(
     prefix: Path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.11"
 dependencies = [
     "click>=8.1",
     "tomlkit>=0.12",
+    "questionary>=2.0",
 ]
 
 [project.scripts]

--- a/tests/test_ext_add.py
+++ b/tests/test_ext_add.py
@@ -31,3 +31,33 @@ def test_collect_add_candidates_splits_three_buckets():
     assert "intl" in rebuild_c
     assert "mysql" in rebuild_c
     assert "pdo_firebird" not in rebuild_c  # kein Variant-Mapping
+
+
+import tomlkit
+from pathlib import Path
+from pbrew.cli.ext import _update_config_variants
+
+
+def test_update_config_variants_adds_without_duplicates(tmp_path: Path):
+    cfg = tmp_path / "default.toml"
+    cfg.write_text(tomlkit.dumps({
+        "build": {"variants": ["default", "opcache"]},
+    }))
+    added = _update_config_variants(cfg, ["intl", "opcache", "soap"])
+    data = tomlkit.loads(cfg.read_text()).unwrap()
+    assert data["build"]["variants"] == [
+        "default", "opcache", "intl", "soap"
+    ]
+    assert added == ["intl", "soap"]
+
+
+def test_update_config_variants_removes(tmp_path: Path):
+    from pbrew.cli.ext import _remove_config_variants
+    cfg = tmp_path / "dev.toml"
+    cfg.write_text(tomlkit.dumps({
+        "build": {"variants": ["default", "opcache", "intl", "soap"]},
+    }))
+    removed = _remove_config_variants(cfg, ["intl", "notthere"])
+    data = tomlkit.loads(cfg.read_text()).unwrap()
+    assert data["build"]["variants"] == ["default", "opcache", "soap"]
+    assert removed == ["intl"]

--- a/tests/test_ext_add.py
+++ b/tests/test_ext_add.py
@@ -7,3 +7,27 @@ def test_pecl_suggestions_contains_popular_names():
     # Keine Dopplung mit Standard-Extensions
     from pbrew.cli.ext import _STANDARD_EXTENSIONS
     assert _PECL_SUGGESTIONS.isdisjoint(_STANDARD_EXTENSIONS)
+
+
+def test_collect_add_candidates_splits_three_buckets():
+    from unittest.mock import patch
+    from pbrew.cli.ext import _collect_add_candidates
+
+    loaded = {"json": ("json", "8.4"), "spl": ("spl", "8.4")}
+    local = ["apcu", "redis"]
+    standard = ["intl", "mysql", "pdo_firebird"]
+    pbrew_active = {"apcu"}  # apcu soll NICHT unter local_candidates landen
+    active_variants = {"opcache"}
+
+    local_c, pecl_c, rebuild_c = _collect_add_candidates(
+        loaded=loaded, local=local, standard=standard,
+        pbrew_active=pbrew_active, active_variants=active_variants,
+    )
+    assert local_c == ["redis"]
+    # pecl_candidates = _PECL_SUGGESTIONS minus loaded/local/standard
+    assert "xdebug" in pecl_c
+    assert "apcu" not in pecl_c          # ist lokal
+    # rebuild_c = standard ∩ VARIANT_EXTENSIONS minus active_variants
+    assert "intl" in rebuild_c
+    assert "mysql" in rebuild_c
+    assert "pdo_firebird" not in rebuild_c  # kein Variant-Mapping

--- a/tests/test_ext_add.py
+++ b/tests/test_ext_add.py
@@ -1,0 +1,9 @@
+def test_pecl_suggestions_contains_popular_names():
+    from pbrew.cli.ext import _PECL_SUGGESTIONS
+    assert "xdebug" in _PECL_SUGGESTIONS
+    assert "apcu" in _PECL_SUGGESTIONS
+    assert "redis" in _PECL_SUGGESTIONS
+    assert "imagick" in _PECL_SUGGESTIONS
+    # Keine Dopplung mit Standard-Extensions
+    from pbrew.cli.ext import _STANDARD_EXTENSIONS
+    assert _PECL_SUGGESTIONS.isdisjoint(_STANDARD_EXTENSIONS)

--- a/tests/test_ext_add_cmd.py
+++ b/tests/test_ext_add_cmd.py
@@ -1,0 +1,89 @@
+import json
+import os
+from unittest.mock import patch, MagicMock
+from click.testing import CliRunner
+from pbrew.cli import main
+
+
+def _setup_version(prefix, family="8.4", version="8.4.22"):
+    (prefix / "versions" / version / "bin").mkdir(parents=True)
+    (prefix / "versions" / version / "bin" / "php").touch()
+    state = prefix / "state"
+    state.mkdir(parents=True, exist_ok=True)
+    (state / f"{family}.json").write_text(json.dumps({"active": version}))
+    (state / "global.json").write_text(json.dumps({"default_family": family}))
+
+
+def _invoke(prefix, tmp_path, *args):
+    runner = CliRunner()
+    env = {"XDG_CONFIG_HOME": str(tmp_path / "config")}
+    with patch.dict(os.environ, env):
+        return runner.invoke(main, ["--prefix", str(prefix)] + list(args))
+
+
+def test_ext_add_requires_tty(tmp_path):
+    _setup_version(tmp_path)
+    with patch("pbrew.cli.ext._query_extensions", return_value=({}, [], [])), \
+         patch("pbrew.cli.ext._is_tty", return_value=False):
+        result = _invoke(tmp_path, tmp_path, "ext", "add", "8.4")
+    assert result.exit_code != 0
+    assert "TTY" in result.output or "interaktiv" in result.output.lower()
+
+
+def test_ext_add_activates_local_so(tmp_path):
+    _setup_version(tmp_path)
+    confd = tmp_path / "etc" / "conf.d" / "8.4"
+    confd.mkdir(parents=True)
+
+    with patch("pbrew.cli.ext._query_extensions", return_value=({}, ["redis"], [])), \
+         patch("pbrew.cli.ext._is_tty", return_value=True), \
+         patch("pbrew.cli.ext._prompt_multiselect",
+               return_value={"Lokale .so": ["redis"]}):
+        result = _invoke(tmp_path, tmp_path, "ext", "add", "8.4")
+
+    assert result.exit_code == 0, result.output
+    assert (confd / "redis.ini").exists()
+    assert "redis" in result.output
+
+
+def test_ext_add_installs_pecl(tmp_path):
+    _setup_version(tmp_path)
+    with patch("pbrew.cli.ext._query_extensions", return_value=({}, [], [])), \
+         patch("pbrew.cli.ext._is_tty", return_value=True), \
+         patch("pbrew.cli.ext._prompt_multiselect",
+               return_value={"PECL": ["xdebug"]}), \
+         patch("pbrew.cli.ext._install_pecl_extension") as inst:
+        result = _invoke(tmp_path, tmp_path, "ext", "add", "8.4")
+    assert result.exit_code == 0, result.output
+    inst.assert_called_once()
+    assert inst.call_args.args[1] == "xdebug"
+
+
+def test_ext_add_rebuild_adds_to_config(tmp_path):
+    _setup_version(tmp_path)
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    (configs / "default.toml").write_text(
+        '[build]\nvariants=["default", "opcache"]\n'
+    )
+    with patch("pbrew.cli.ext._query_extensions", return_value=({}, [], ["intl"])), \
+         patch("pbrew.cli.ext._is_tty", return_value=True), \
+         patch("pbrew.cli.ext._prompt_multiselect",
+               return_value={"Standard (Rebuild)": ["intl"]}), \
+         patch("pbrew.cli.ext._prompt_config_choice",
+               return_value=configs / "default.toml"):
+        result = _invoke(tmp_path, tmp_path, "ext", "add", "8.4")
+    assert result.exit_code == 0, result.output
+    assert "Rebuild" in result.output or "rebuild" in result.output.lower()
+    text = (configs / "default.toml").read_text()
+    assert "intl" in text
+
+
+def test_ext_add_nothing_selected(tmp_path):
+    _setup_version(tmp_path)
+    with patch("pbrew.cli.ext._query_extensions", return_value=({}, ["redis"], [])), \
+         patch("pbrew.cli.ext._is_tty", return_value=True), \
+         patch("pbrew.cli.ext._prompt_multiselect", return_value={}):
+        result = _invoke(tmp_path, tmp_path, "ext", "add", "8.4")
+    assert result.exit_code == 0
+    assert "Nichts" in result.output or "abgebrochen" in result.output.lower()

--- a/tests/test_ext_add_cmd.py
+++ b/tests/test_ext_add_cmd.py
@@ -79,6 +79,29 @@ def test_ext_add_rebuild_adds_to_config(tmp_path):
     assert "intl" in text
 
 
+def test_ext_add_rebuild_creates_new_config(tmp_path):
+    _setup_version(tmp_path)
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    new_cfg = configs / "myprofile.toml"
+    # Neue Config existiert noch nicht
+    assert not new_cfg.exists()
+    with patch("pbrew.cli.ext._query_extensions", return_value=({}, [], ["intl"])), \
+         patch("pbrew.cli.ext._is_tty", return_value=True), \
+         patch("pbrew.cli.ext._prompt_multiselect",
+               return_value={"Standard (Rebuild)": ["intl"]}), \
+         patch("pbrew.cli.ext._prompt_config_choice",
+               return_value=new_cfg):
+        result = _invoke(tmp_path, tmp_path, "ext", "add", "8.4")
+    assert result.exit_code == 0, result.output
+    assert new_cfg.exists()
+    import tomlkit
+    data = tomlkit.loads(new_cfg.read_text()).unwrap()
+    assert "intl" in data["build"]["variants"]
+    # Kein active_variants-Überlauf: nur rebuild_picks sollen drin sein
+    assert "opcache" not in data["build"]["variants"]
+
+
 def test_ext_add_nothing_selected(tmp_path):
     _setup_version(tmp_path)
     with patch("pbrew.cli.ext._query_extensions", return_value=({}, ["redis"], [])), \

--- a/tests/test_ext_config_prompt.py
+++ b/tests/test_ext_config_prompt.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+from pbrew.cli.ext import _prompt_config_choice
+
+
+def test_prompt_config_choice_existing(tmp_path: Path):
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    (configs / "default.toml").write_text("[build]\nvariants=[\"default\"]\n")
+    (configs / "dev.toml").write_text("[build]\nvariants=[\"default\"]\n")
+
+    mock_q = MagicMock()
+    mock_q.ask.return_value = "dev.toml"
+    with patch("pbrew.cli.ext.questionary.select", return_value=mock_q):
+        choice = _prompt_config_choice(configs, active_family="8.4")
+    assert choice == configs / "dev.toml"
+
+
+def test_prompt_config_choice_new(tmp_path: Path):
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    (configs / "default.toml").write_text("[build]\nvariants=[\"default\"]\n")
+
+    select_mock = MagicMock()
+    select_mock.ask.return_value = "<neu>"
+    text_mock = MagicMock()
+    text_mock.ask.return_value = "myprofile"
+    with patch("pbrew.cli.ext.questionary.select", return_value=select_mock), \
+         patch("pbrew.cli.ext.questionary.text", return_value=text_mock):
+        choice = _prompt_config_choice(configs, active_family="8.4")
+    assert choice == configs / "myprofile.toml"

--- a/tests/test_ext_multiselect.py
+++ b/tests/test_ext_multiselect.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch, MagicMock
+from pbrew.cli.ext import _prompt_multiselect
+
+
+def test_prompt_multiselect_groups_and_returns_choices():
+    mock = MagicMock()
+    mock.ask.return_value = ["Lokale .so::redis", "Standard (Rebuild)::intl"]
+    groups = {
+        "Lokale .so": ["redis"],
+        "PECL": ["xdebug"],
+        "Standard (Rebuild)": ["intl", "mysql"],
+    }
+    with patch("pbrew.cli.ext.questionary.checkbox", return_value=mock) as cb:
+        result = _prompt_multiselect("Was hinzufuegen?", groups)
+    assert result == {"Lokale .so": ["redis"], "Standard (Rebuild)": ["intl"]}
+    # sichergehen, dass Separators gebaut wurden
+    called_choices = cb.call_args.kwargs["choices"]
+    assert any(getattr(c, "title", None) is not None for c in called_choices) \
+        or any("Separator" in type(c).__name__ for c in called_choices)
+
+
+def test_prompt_multiselect_returns_empty_on_abort():
+    mock = MagicMock()
+    mock.ask.return_value = None
+    with patch("pbrew.cli.ext.questionary.checkbox", return_value=mock):
+        result = _prompt_multiselect("x", {"g": ["a"]})
+    assert result == {}

--- a/tests/test_ext_remove_interactive.py
+++ b/tests/test_ext_remove_interactive.py
@@ -1,0 +1,85 @@
+import json
+import os
+import tomlkit
+from unittest.mock import patch
+from click.testing import CliRunner
+from pbrew.cli import main
+
+
+def _setup(prefix, family="8.4", version="8.4.22"):
+    (prefix / "versions" / version / "bin").mkdir(parents=True)
+    (prefix / "versions" / version / "bin" / "php").touch()
+    s = prefix / "state"
+    s.mkdir(parents=True, exist_ok=True)
+    (s / f"{family}.json").write_text(json.dumps({"active": version}))
+    (s / "global.json").write_text(json.dumps({"default_family": family}))
+
+
+def _invoke(prefix, tmp_path, *args):
+    runner = CliRunner()
+    env = {"XDG_CONFIG_HOME": str(tmp_path / "config")}
+    with patch.dict(os.environ, env):
+        return runner.invoke(main, ["--prefix", str(prefix)] + list(args))
+
+
+def test_ext_remove_positional_still_works(tmp_path):
+    _setup(tmp_path)
+    confd = tmp_path / "etc" / "conf.d" / "8.4"
+    confd.mkdir(parents=True)
+    (confd / "apcu.ini").write_text("extension=apcu.so\n")
+    result = _invoke(tmp_path, tmp_path, "ext", "remove", "apcu", "8.4")
+    assert result.exit_code == 0, result.output
+    assert (confd / "apcu.ini.disabled").exists()
+
+
+def test_ext_remove_interactive_active_ini(tmp_path):
+    _setup(tmp_path)
+    confd = tmp_path / "etc" / "conf.d" / "8.4"
+    confd.mkdir(parents=True)
+    (confd / "apcu.ini").write_text("extension=apcu.so\n")
+
+    with patch("pbrew.cli.ext._query_extensions",
+               return_value=({"apcu": ("apcu", "5.1")}, [], [])), \
+         patch("pbrew.cli.ext._is_tty", return_value=True), \
+         patch("pbrew.cli.ext._prompt_multiselect",
+               return_value={"Aktive pbrew-INI": ["apcu"]}):
+        result = _invoke(tmp_path, tmp_path, "ext", "remove", "8.4")
+    assert result.exit_code == 0, result.output
+    assert (confd / "apcu.ini.disabled").exists()
+
+
+def test_ext_remove_interactive_disabled_ini_deletes_file(tmp_path):
+    _setup(tmp_path)
+    confd = tmp_path / "etc" / "conf.d" / "8.4"
+    confd.mkdir(parents=True)
+    (confd / "old.ini.disabled").write_text("x\n")
+
+    with patch("pbrew.cli.ext._query_extensions",
+               return_value=({}, [], [])), \
+         patch("pbrew.cli.ext._is_tty", return_value=True), \
+         patch("pbrew.cli.ext._prompt_multiselect",
+               return_value={"Inaktive pbrew-INI": ["old"]}):
+        result = _invoke(tmp_path, tmp_path, "ext", "remove", "8.4")
+    assert result.exit_code == 0, result.output
+    assert not (confd / "old.ini.disabled").exists()
+
+
+def test_ext_remove_interactive_removes_variant(tmp_path):
+    _setup(tmp_path)
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    (configs / "default.toml").write_text(
+        '[build]\nvariants=["default", "intl", "opcache"]\n'
+    )
+    with patch("pbrew.cli.ext._query_extensions",
+               return_value=({"intl": ("intl", "74.2")}, [], [])), \
+         patch("pbrew.cli.ext._is_tty", return_value=True), \
+         patch("pbrew.cli.ext._prompt_multiselect",
+               return_value={"Kompiliert (Rebuild)": ["intl"]}), \
+         patch("pbrew.cli.ext._prompt_config_choice",
+               return_value=configs / "default.toml"):
+        result = _invoke(tmp_path, tmp_path, "ext", "remove", "8.4")
+    assert result.exit_code == 0, result.output
+    data = tomlkit.loads((configs / "default.toml").read_text()).unwrap()
+    assert "intl" not in data["build"]["variants"]
+    assert "Rebuild" in result.output or "rebuild" in result.output.lower()

--- a/tests/test_variant_flags_exports.py
+++ b/tests/test_variant_flags_exports.py
@@ -1,0 +1,16 @@
+from pbrew.core.builder import VARIANT_FLAGS, VARIANT_EXTENSIONS
+
+
+def test_variant_flags_exposes_mapping():
+    assert "opcache" in VARIANT_FLAGS
+    assert VARIANT_FLAGS["mysql"] == [
+        "--enable-mysqli", "--with-mysqli=mysqlnd", "--with-pdo-mysql=mysqlnd",
+    ]
+
+
+def test_variant_extensions_excludes_sapi_entries():
+    assert "cli" not in VARIANT_EXTENSIONS
+    assert "fpm" not in VARIANT_EXTENSIONS
+    assert "fpm-systemd" not in VARIANT_EXTENSIONS
+    assert "opcache" in VARIANT_EXTENSIONS
+    assert "mysql" in VARIANT_EXTENSIONS


### PR DESCRIPTION
## Summary

- Führt `pbrew ext add [PHP-VERSION]` ein: interaktiver Multi-Select-Dialog mit drei Gruppen (lokale `.so` aktivieren, PECL installieren, Standard-Extensions für Config-Rebuild markieren)
- Erweitert `pbrew ext remove [EXT] [PHP-VERSION]`: ohne `EXT`-Argument interaktiver Modus (INIs deaktivieren, `.ini.disabled` löschen, Variants aus Config entfernen); mit `EXT` unverändertes bisheriges Verhalten
- Neue Runtime-Dependency: `questionary>=2.0` für TUI-Checkboxen/Selects
- Öffentliche API: `VARIANT_FLAGS`, `VARIANT_EXTENSIONS` in `pbrew.core.builder`

## Test Plan

- [ ] `pytest -v -k ext` – 58 Tests grün
- [ ] `pbrew ext add 8.4` in einer Shell mit TTY – Dialog erscheint mit drei Gruppen
- [ ] `pbrew ext remove 8.4` ohne Extension-Name – interaktiver Dialog
- [ ] `pbrew ext remove apcu 8.4` mit Name – klassisches Deaktivieren wie bisher
- [ ] Ohne TTY (z.B. in einem Script) – saubere Fehlermeldung "Interaktiver Modus benoetigt ein TTY"

Closes #79